### PR TITLE
README: show how to get the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ This is an early stage project so far. Feel free to contribute.
 First Steps
 ===========
 
+Install dependencies:
+
+```
+go get github.com/streadway/amqp
+go get gopkg.in/yaml.v2
+
+# or run
+
+make
+```
+
 Add the Machinery library to your $GOPATH/src:
 
 ```


### PR DESCRIPTION
Being explicit about deps in README. Addresses #2 