### PR TITLE
Reflection in order to avoid using empty interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func AddTask(args ...float64) (float64, error) {
 
 // MultiplyTask ...
 func MultiplyTask(args ...float64) (float64, error) {
-	sum := 0.0
+	sum := 1.0
 	for _, arg := range args {
 		sum *= arg
 	}

--- a/README.md
+++ b/README.md
@@ -85,54 +85,27 @@ Each worker will only consume registered tasks.
 Tasks
 =====
 
-Tasks are a building block of Machinery applications. A task is a struct which implements a simple interface:
+Tasks are a building block of Machinery applications. A task is a function which defines what happens when a worker receives a message. Let's say we want to define tasks for adding and multiplying numbers:
 
 ```go
-type Task interface {
-	Run(args []interface{}) (interface{}, error)
-}
-```
-
-A task defines what happens when a worker receives a message. Let's say we want to define tasks for adding and multiplying numbers:
-
-```go
-type AddTask struct{}
-
-func (t AddTask) Run(args []interface{}) (interface{}, error) {
-	parsedArgs, err := machinery.ParseNumberArgs(args)
-	if err != nil {
-		return nil, err
+// AddTask ...
+func AddTask(args ...float64) (float64, error) {
+	sum := 0.0
+	for _, arg := range args {
+		sum += arg
 	}
-
-	add := func(args []float64) float64 {
-		sum := 0.0
-		for _, arg := range args {
-			sum += arg
-		}
-		return sum
-	}
-
-	return add(parsedArgs), nil
+	return sum, nil
 }
 
-type MultiplyTask struct{}
-
-func (t MultiplyTask) Run(args []interface{}) (interface{}, error) {
-	parsedArgs, err := machinery.ParseNumberArgs(args)
-	if err != nil {
-		return nil, err
+// MultiplyTask ...
+func MultiplyTask(args ...float64) (float64, error) {
+	sum := 0.0
+	for _, arg := range args {
+		sum *= arg
 	}
-
-	multiply := func(args []float64) float64 {
-		sum := 1.0
-		for _, arg := range args {
-			sum *= arg
-		}
-		return sum
-	}
-
-	return multiply(parsedArgs), nil
+	return sum, nil
 }
+
 
 // ... more tasks
 ```
@@ -140,21 +113,20 @@ func (t MultiplyTask) Run(args []interface{}) (interface{}, error) {
 Registering Tasks
 -----------------
 
-Before your workers can consume a task, you need to register it with an App instance. This is done by assigning a task signature a unique name and registering it with an App instance:
+Before your workers can consume a task, you need to register it with an App instance. This is done by assigning a task a unique name and registering it with an App instance:
 
 ```go
-tasks := map[string]machinery.Task{
-    "add":      AddTask{},
-    "multiply": MultiplyTask{},
-}
-app.RegisterTasks(tasks)
+app.RegisterTasks(map[string]interface{}{
+    "add":      AddTask,
+    "multiply": MultiplyTask,
+})
 ```
 
 Task can also be registered one by one:
 
 ```go
-app.RegisterTask("add", AddTask{})
-app.RegisterTask("multiply", MultiplyTask{})
+app.RegisterTask("add", AddTask)
+app.RegisterTask("multiply", MultiplyTask)
 ```
 
 The above code snippet would register two tasks against the App instance:
@@ -167,14 +139,23 @@ Simply put, when a worker receives a message like this:
 ```json
 {
     "Name": "add",
-    "Args": [1, 1],
+    "Args": [
+        {
+            "Type": "float64",
+            "Value": 1,
+        },
+        {
+            "Type": "float64",
+            "Value": 1,
+        }
+    ],
     "Immutable": false,
     "OnSuccess": null,
     "OnError": null
 }
 ```
 
-It will call Run method of AddTask with [1, 1] arguments.
+It will call AddTask(1, 1). Each task should return an error as well so we can handle failures.
 
 Ideally, tasks should be idempotent which means there will be no unintended consequences when a task is called multiple times with the same arguments.
 
@@ -184,9 +165,14 @@ Signatures
 A signature wraps calling arguments, execution options (such as immutability) and success/error callbacks of a task so it can be send across the wire to workers. Task signatures implement a simple interface:
 
 ```go
+type TaskArg struct {
+	Type  string
+	Value interface{}
+}
+
 type TaskSignature struct {
 	Name, RoutingKey string
-	Args             []interface{}
+	Args             []TaskArg
 	Immutable        bool
 	OnSuccess        []*TaskSignature
 	OnError          []*TaskSignature
@@ -210,12 +196,22 @@ Tasks can be called by passing an instance of TaskSignature to an App instance. 
 
 ```go
 task := machinery.TaskSignature{
-    Name:      "add",
-    Args:      []interface{}{1, 1},
+    Name: "add",
+    Args: []machinery.TaskArg{
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(1),
+        },
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(1),
+        },
+    },
 }
 
 err := app.SendTask(&task1)
 if err != nil {
+    // failed to send the task
     // do something with the error
 }
 ```
@@ -233,21 +229,45 @@ Chain is simply a set of tasks which will be executed one by one, each successfu
 ```go
 task1 := machinery.TaskSignature{
     Name: "add",
-    Args: []interface{}{1, 1},
+    Args: []machinery.TaskArg{
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(1),
+        },
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(1),
+        },
+    },
 }
 
 task2 := machinery.TaskSignature{
     Name: "add",
-    Args: []interface{}{5, 6},
+    Args: []machinery.TaskArg{
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(5),
+        },
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(6),
+        },
+    },
 }
 
 task3 := machinery.TaskSignature{
     Name: "multiply",
-    Args: []interface{}{4},
+    Args: []machinery.TaskArg{
+        machinery.TaskArg{
+            Type:  "float64",
+            Value: interface{}(4),
+        },
+    },
 }
 
 err := app.SendTask(machinery.Chain(task1, task2, task3))
 if err != nil {
+    // failed to send the task
     // do something with the error
 }
 ```

--- a/examples/send/send.go
+++ b/examples/send/send.go
@@ -1,20 +1,19 @@
-/*
- * Sending a task
- * --------------
- *
- * This example demonstrates a simple workflow consisting of multiple
- * chained tasks. For each task you can specify success and error callbacks.
- *
- * When a task is successful, its return value will be prepended to args
- * of all success callbacks (signatures in TaskSignature.OnSuccess) and they
- * will then be sent to the queue.
- *
- * When a task fails, error will be prepended to all args of all error
- * callbacks (signatures in TaskSignature.OnError) and they
- * will then sent to the queue.
- *
- * The workflow bellow will result in ((1 + 1) + (5 + 6)) * 4 = 13 * 4 = 52
- */
+//
+// Sending a task
+// --------------
+//
+// This example demonstrates a simple workflow consisting of multiple
+// chained tasks. For each task you can specify success and error callbacks.
+//
+// When a task is successful, its return value will be prepended to args
+// of all success callbacks (signatures in TaskSignature.OnSuccess) and they
+// will then be sent to the queue.
+//
+// When a task fails, error will be prepended to all args of all error
+// callbacks (signatures in TaskSignature.OnError) and they
+// will then sent to the queue.
+//
+// The workflow bellow will result in ((1 + 1) + (5 + 6)) * 4 = 13 * 4 = 52
 
 package main
 
@@ -66,17 +65,40 @@ func init() {
 func main() {
 	task1 := machinery.TaskSignature{
 		Name: "add",
-		Args: []interface{}{1, 1},
+		Args: []machinery.TaskArg{
+			machinery.TaskArg{
+				Type:  "float64",
+				Value: interface{}(1),
+			},
+			machinery.TaskArg{
+				Type:  "float64",
+				Value: interface{}(1),
+			},
+		},
 	}
 
 	task2 := machinery.TaskSignature{
 		Name: "add",
-		Args: []interface{}{5, 6},
+		Args: []machinery.TaskArg{
+			machinery.TaskArg{
+				Type:  "float64",
+				Value: interface{}(5),
+			},
+			machinery.TaskArg{
+				Type:  "float64",
+				Value: interface{}(6),
+			},
+		},
 	}
 
 	task3 := machinery.TaskSignature{
 		Name: "multiply",
-		Args: []interface{}{4},
+		Args: []machinery.TaskArg{
+			machinery.TaskArg{
+				Type:  "float64",
+				Value: interface{}(4),
+			},
+		},
 	}
 
 	// Let's go!

--- a/examples/tasks/tasks.go
+++ b/examples/tasks/tasks.go
@@ -1,49 +1,19 @@
-// Package exampletasks - some sample tasks
-// Each task should implement v1.Task interface.
-// Put your business logic inside the Run method.
-// Task arguments are available in the args slice.
 package exampletasks
 
-import machinery "github.com/RichardKnop/machinery/v1"
-
 // AddTask ...
-type AddTask struct{}
-
-// Run - runs the task and returns sum of all numbers in args
-func (t AddTask) Run(args []interface{}) (interface{}, error) {
-	parsedArgs, err := machinery.ParseNumberArgs(args)
-	if err != nil {
-		return nil, err
+func AddTask(args ...float64) (float64, error) {
+	sum := 0.0
+	for _, arg := range args {
+		sum += arg
 	}
-
-	add := func(args []float64) float64 {
-		sum := 0.0
-		for _, arg := range args {
-			sum += arg
-		}
-		return sum
-	}
-
-	return add(parsedArgs), nil
+	return sum, nil
 }
 
 // MultiplyTask ...
-type MultiplyTask struct{}
-
-// Run - runs the task and returns result of all numbers in args multiplied
-func (t MultiplyTask) Run(args []interface{}) (interface{}, error) {
-	parsedArgs, err := machinery.ParseNumberArgs(args)
-	if err != nil {
-		return nil, err
+func MultiplyTask(args ...float64) (float64, error) {
+	sum := 0.0
+	for _, arg := range args {
+		sum *= arg
 	}
-
-	multiply := func(args []float64) float64 {
-		sum := 1.0
-		for _, arg := range args {
-			sum *= arg
-		}
-		return sum
-	}
-
-	return multiply(parsedArgs), nil
+	return sum, nil
 }

--- a/examples/tasks/tasks.go
+++ b/examples/tasks/tasks.go
@@ -11,7 +11,7 @@ func AddTask(args ...float64) (float64, error) {
 
 // MultiplyTask ...
 func MultiplyTask(args ...float64) (float64, error) {
-	sum := 0.0
+	sum := 1.0
 	for _, arg := range args {
 		sum *= arg
 	}

--- a/examples/worker/worker.go
+++ b/examples/worker/worker.go
@@ -1,21 +1,20 @@
-/*
- * A worker example
- * ----------------
- *
- * This is how a Machinery worker could look.
- *
- * Preferred way to launch a new worker process is by using a configuration file
- * (see config.yml in this directory for an example):
- * ./worker -c /path/to/config.yml
- *
- *
- * Optionally, you could pass command line flags:
- * ./worker -b amqp://guest:guest@localhost:5672/ -q tast_queue
- *
- * Once the worker process is up and running, it subscribes to the defined queue
- * and waits for incoming tasks. When a new task is published, the worker will
- * process it if it has been registered with the app.
- */
+//
+// A worker example
+// ----------------
+//
+// This is how a Machinery worker could look.
+//
+// Preferred way to launch a new worker process is by using a configuration file
+// (see config.yml in this directory for an example):
+// ./worker -c /path/to/config.yml
+//
+//
+// Optionally, you could pass command line flags:
+// ./worker -b amqp://guest:guest@localhost:5672/ -q tast_queue
+//
+// Once the worker process is up and running, it subscribes to the defined queue
+// and waits for incoming tasks. When a new task is published, the worker will
+// process it if it has been registered with the app.
 
 package main
 
@@ -66,9 +65,9 @@ func init() {
 	errors.Fail(err, "Could not init App")
 
 	// Register tasks
-	tasks := map[string]machinery.Task{
-		"add":      exampletasks.AddTask{},
-		"multiply": exampletasks.MultiplyTask{},
+	tasks := map[string]interface{}{
+		"add":      exampletasks.AddTask,
+		"multiply": exampletasks.MultiplyTask,
 	}
 	app.RegisterTasks(tasks)
 

--- a/v1/app.go
+++ b/v1/app.go
@@ -12,7 +12,7 @@ import (
 // App.SendTask is one way of sending a task to workers
 type App struct {
 	config          *config.Config
-	registeredTasks map[string]Task
+	registeredTasks map[string]interface{}
 	connection      Connectable
 }
 
@@ -28,7 +28,7 @@ func InitApp(cnf *config.Config) (*App, error) {
 
 	return &App{
 		config:          cnf,
-		registeredTasks: make(map[string]Task),
+		registeredTasks: make(map[string]interface{}),
 		connection:      conn,
 	}, nil
 }
@@ -44,17 +44,17 @@ func (app *App) GetConfig() *config.Config {
 }
 
 // RegisterTasks registers all tasks at once
-func (app *App) RegisterTasks(tasks map[string]Task) {
+func (app *App) RegisterTasks(tasks map[string]interface{}) {
 	app.registeredTasks = tasks
 }
 
 // RegisterTask registers a single task
-func (app *App) RegisterTask(name string, task Task) {
+func (app *App) RegisterTask(name string, task interface{}) {
 	app.registeredTasks[name] = task
 }
 
 // GetRegisteredTask returns registered task by name
-func (app *App) GetRegisteredTask(name string) Task {
+func (app *App) GetRegisteredTask(name string) interface{} {
 	return app.registeredTasks[name]
 }
 

--- a/v1/app_test.go
+++ b/v1/app_test.go
@@ -8,10 +8,6 @@ import (
 
 type testTask struct{}
 
-func (t testTask) Run(args []interface{}) (interface{}, error) {
-	return nil, nil
-}
-
 func TestRegisterTasks(t *testing.T) {
 	app, err := InitApp(&config.Config{
 		BrokerURL:    "amqp://guest:guest@localhost:5672/",
@@ -24,8 +20,8 @@ func TestRegisterTasks(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.RegisterTasks(map[string]Task{
-		"test_task": testTask{},
+	app.RegisterTasks(map[string]interface{}{
+		"test_task": func() {},
 	})
 
 	if app.GetRegisteredTask("test_task") == nil {
@@ -45,7 +41,7 @@ func TestRegisterTask(t *testing.T) {
 		t.Error(err)
 	}
 
-	app.RegisterTask("test_task", testTask{})
+	app.RegisterTask("test_task", func() {})
 
 	if app.GetRegisteredTask("test_task") == nil {
 		t.Error("test_task is not registered but it should be")

--- a/v1/reflect.go
+++ b/v1/reflect.go
@@ -1,0 +1,68 @@
+package machinery
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	typesMap = map[string]reflect.Type{
+		"int":     reflect.TypeOf(int(1)),
+		"int8":    reflect.TypeOf(int8(1)),
+		"int16":   reflect.TypeOf(int16(1)),
+		"int32":   reflect.TypeOf(int32(1)),
+		"int64":   reflect.TypeOf(int64(1)),
+		"uint":    reflect.TypeOf(uint(1)),
+		"float32": reflect.TypeOf(float32(0.5)),
+		"float64": reflect.TypeOf(float64(0.5)),
+		"string":  reflect.TypeOf(string("")),
+	}
+)
+
+// ReflectArgs converts []TaskArg to []reflect.Value
+func ReflectArgs(args []TaskArg) ([]reflect.Value, error) {
+	argValues := make([]reflect.Value, len(args))
+
+	for i, arg := range args {
+		argType := typesMap[arg.Type]
+		argTypeString := argType.String()
+		argValue := reflect.New(argType)
+
+		if strings.HasPrefix(argTypeString, "int") {
+			intValue, ok := arg.Value.(int64)
+			if !ok {
+				return nil, fmt.Errorf("%v is not %v", arg.Value, argTypeString)
+			}
+			argValue.Elem().SetInt(intValue)
+		}
+
+		if argTypeString == "uint" {
+			uintValue, ok := arg.Value.(uint64)
+			if !ok {
+				return nil, fmt.Errorf("%v is not %v", arg.Value, argTypeString)
+			}
+			argValue.Elem().SetUint(uintValue)
+		}
+
+		if strings.HasPrefix(argTypeString, "float") {
+			floatValue, ok := arg.Value.(float64)
+			if !ok {
+				return nil, fmt.Errorf("%v is not %v", arg.Value, argTypeString)
+			}
+			argValue.Elem().SetFloat(floatValue)
+		}
+
+		if argTypeString == "string" {
+			stringValue, ok := arg.Value.(string)
+			if !ok {
+				return nil, fmt.Errorf("%v is not %v", arg.Value, argTypeString)
+			}
+			argValue.Elem().SetString(stringValue)
+		}
+
+		argValues[i] = argValue.Elem()
+	}
+
+	return argValues, nil
+}

--- a/v1/tasks.go
+++ b/v1/tasks.go
@@ -1,15 +1,15 @@
 package machinery
 
-// Task is a common interface all registered tasks
-// must implement
-type Task interface {
-	Run(args []interface{}) (interface{}, error)
+// TaskArg represents a single argument passed to invocation fo a task
+type TaskArg struct {
+	Type  string
+	Value interface{}
 }
 
 // TaskSignature represents a single task invocation
 type TaskSignature struct {
 	Name, RoutingKey string
-	Args             []interface{}
+	Args             []TaskArg
 	Immutable        bool
 	OnSuccess        []*TaskSignature
 	OnError          []*TaskSignature

--- a/v1/workflow_test.go
+++ b/v1/workflow_test.go
@@ -5,17 +5,40 @@ import "testing"
 func TestChain(t *testing.T) {
 	task1 := TaskSignature{
 		Name: "foo",
-		Args: []interface{}{1, 1},
+		Args: []TaskArg{
+			TaskArg{
+				Type:  "float64",
+				Value: interface{}(1),
+			},
+			TaskArg{
+				Type:  "float64",
+				Value: interface{}(1),
+			},
+		},
 	}
 
 	task2 := TaskSignature{
 		Name: "bar",
-		Args: []interface{}{5, 6},
+		Args: []TaskArg{
+			TaskArg{
+				Type:  "float64",
+				Value: interface{}(5),
+			},
+			TaskArg{
+				Type:  "float64",
+				Value: interface{}(6),
+			},
+		},
 	}
 
 	task3 := TaskSignature{
 		Name: "qux",
-		Args: []interface{}{4},
+		Args: []TaskArg{
+			TaskArg{
+				Type:  "float64",
+				Value: interface{}(4),
+			},
+		},
 	}
 
 	chain := Chain(task1, task2, task3)


### PR DESCRIPTION
Instead of having to parse empty interfaces inside tasks, I will be using reflection to apply some magic when consuming messages so tasks can have properly typed input arguments as well as return values.