### PR TITLE
AMPQ. Thread-safe connection reusing

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -37,6 +37,7 @@ func (amqpBroker *AMQPBroker) StartConsuming(consumerTag string, taskProcessor T
 	}
 
 	_, channel, queue, _, err := amqpBroker.open()
+	defer channel.Close()
 	if err != nil {
 		amqpBroker.retryFunc()
 		return true, err // retry true
@@ -166,7 +167,7 @@ func (amqpBroker *AMQPBroker) consume(deliveries <-chan amqp.Delivery, taskProce
 	}
 }
 
-// Connects to the message queue, opens a channel, declares a queue
+// Connects to the message queue
 func (amqpBroker *AMQPBroker) connect() {
 
 	var err error
@@ -184,12 +185,7 @@ func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queu
 	var channel *amqp.Channel
 	var queue amqp.Queue
 	if conn == nil {
-		connected := make(chan bool)
-		go func() {
-			once.Do(amqpBroker.connect)
-			connected <- true
-		}()
-		<-connected
+		once.Do(amqpBroker.connect)
 	}
 
 	if conn == nil {


### PR DESCRIPTION
Issue https://github.com/RichardKnop/machinery/issues/26
I'm trying to make it thread safe to allow goroutined SendTask
```
	go server.SendTask(&task0)
	go server.SendTask(&task1)
	go server.SendTask(&task2)
```

Also I removed the connection/channel close method cause of no need in it in the case of shared connection