### PR TITLE
Do not rewrite import paths

### DIFF
--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/streadway/amqp"
+	"github.com/streadway/amqp"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )

--- a/v1/backends/eager_test.go
+++ b/v1/backends/eager_test.go
@@ -3,7 +3,7 @@ package backends
 import (
 	"testing"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/suite"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )
 

--- a/v1/backends/memcache.go
+++ b/v1/backends/memcache.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/bradfitz/gomemcache/memcache"
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/garyburd/redigo/redis"
+	"github.com/garyburd/redigo/redis"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/streadway/amqp"
+	"github.com/streadway/amqp"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/RichardKnop/machinery/v1/utils"

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/garyburd/redigo/redis"
+	"github.com/garyburd/redigo/redis"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/RichardKnop/machinery/v1/utils"

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Config holds all configuration for our program

--- a/v1/eager_test.go
+++ b/v1/eager_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/suite"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )

--- a/v1/server.go
+++ b/v1/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"code.google.com/p/go-uuid/uuid"
 	"github.com/RichardKnop/machinery/v1/backends"
 	"github.com/RichardKnop/machinery/v1/brokers"
 	"github.com/RichardKnop/machinery/v1/config"

--- a/v1/workflow.go
+++ b/v1/workflow.go
@@ -3,7 +3,7 @@ package machinery
 import (
 	"fmt"
 
-	"github.com/RichardKnop/machinery/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"code.google.com/p/go-uuid/uuid"
 	"github.com/RichardKnop/machinery/v1/signatures"
 )
 


### PR DESCRIPTION
Was there any particular reason for importing packages from the Godeps directory?

Edit: On further investigation I found out that `godep save -r` does the package import rewrite. I personally do not like this and I prefer `go get`able packages. Would you be interested in making this package compatible with the Go 1.5 vendoring experiment? Apparently [godep](https://github.com/tools/godep#go-15-vendor-experiment) has some support for this.