### PR TITLE
Worker registered task consume bug fix

### DIFF
--- a/integrationtests/worker_only_consumes_registered_tasks_test.go
+++ b/integrationtests/worker_only_consumes_registered_tasks_test.go
@@ -1,0 +1,222 @@
+package integrationtests
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	machinery "github.com/RichardKnop/machinery/v1"
+	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/errors"
+	"github.com/RichardKnop/machinery/v1/signatures"
+)
+
+func TestWorkerOnlyConsumesRegisteredTaskAMQP(t *testing.T) {
+	amqpURL := os.Getenv("AMQP_URL")
+
+	if amqpURL != "" {
+		cnf := config.Config{
+			Broker:        amqpURL,
+			ResultBackend: amqpURL,
+			Exchange:      "test_exchange",
+			ExchangeType:  "direct",
+			DefaultQueue:  "test_queue",
+			BindingKey:    "test_task",
+		}
+
+		server1, err := machinery.NewServer(&cnf)
+		errors.Fail(err, "Could not initialize server")
+
+		server1.RegisterTask("add", func(args ...int64) (int64, error) {
+			sum := int64(0)
+			for _, arg := range args {
+				sum += arg
+			}
+			return sum, nil
+		})
+
+		server2, err := machinery.NewServer(&cnf)
+		errors.Fail(err, "Could not initialize server")
+
+		server2.RegisterTask("multiply", func(args ...int64) (int64, error) {
+			sum := int64(1)
+			for _, arg := range args {
+				sum *= arg
+			}
+			return sum, nil
+		})
+
+		task1 := signatures.TaskSignature{
+			Name: "add",
+			Args: []signatures.TaskArg{
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 2,
+				},
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 3,
+				},
+			},
+		}
+
+		task2 := signatures.TaskSignature{
+			Name: "multiply",
+			Args: []signatures.TaskArg{
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 4,
+				},
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 5,
+				},
+			},
+		}
+
+		worker1 := server1.NewWorker("test_worker")
+		worker2 := server2.NewWorker("test_worker2")
+		go worker1.Launch()
+		go worker2.Launch()
+
+		group := machinery.NewGroup(&task2, &task1)
+		asyncResults, err := server1.SendGroup(group)
+		if err != nil {
+			t.Error(err)
+		}
+
+		expectedResults := []int64{5, 20}
+		actualResults := make([]int64, 2)
+
+		for i, asyncResult := range asyncResults {
+			result, err := asyncResult.Get()
+			if err != nil {
+				t.Error(err)
+			}
+			intResult, ok := result.Interface().(int64)
+			if !ok {
+				t.Errorf("Could not convert %v to int64", result.Interface())
+			}
+			actualResults[i] = intResult
+		}
+
+		worker1.Quit()
+		worker2.Quit()
+
+		sort.Sort(ascendingInt64s(actualResults))
+
+		if !reflect.DeepEqual(expectedResults, actualResults) {
+			t.Errorf(
+				"expected results = %v, actual results = %v",
+				expectedResults,
+				actualResults,
+			)
+		}
+	}
+}
+
+func TestWorkerOnlyConsumesRegisteredTaskRedis(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+
+	if redisURL != "" {
+		cnf := config.Config{
+			Broker:        fmt.Sprintf("redis://%v", redisURL),
+			ResultBackend: fmt.Sprintf("redis://%v", redisURL),
+			Exchange:      "test_exchange",
+			ExchangeType:  "direct",
+			DefaultQueue:  "test_queue",
+			BindingKey:    "test_task",
+		}
+
+		server1, err := machinery.NewServer(&cnf)
+		errors.Fail(err, "Could not initialize server")
+
+		server1.RegisterTask("add", func(args ...int64) (int64, error) {
+			sum := int64(0)
+			for _, arg := range args {
+				sum += arg
+			}
+			return sum, nil
+		})
+
+		server2, err := machinery.NewServer(&cnf)
+		errors.Fail(err, "Could not initialize server")
+
+		server2.RegisterTask("multiply", func(args ...int64) (int64, error) {
+			sum := int64(1)
+			for _, arg := range args {
+				sum *= arg
+			}
+			return sum, nil
+		})
+
+		task1 := signatures.TaskSignature{
+			Name: "add",
+			Args: []signatures.TaskArg{
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 2,
+				},
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 3,
+				},
+			},
+		}
+
+		task2 := signatures.TaskSignature{
+			Name: "multiply",
+			Args: []signatures.TaskArg{
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 4,
+				},
+				signatures.TaskArg{
+					Type:  "int64",
+					Value: 5,
+				},
+			},
+		}
+
+		worker1 := server1.NewWorker("test_worker")
+		worker2 := server2.NewWorker("test_worker2")
+		go worker1.Launch()
+		go worker2.Launch()
+
+		group := machinery.NewGroup(&task2, &task1)
+		asyncResults, err := server1.SendGroup(group)
+		if err != nil {
+			t.Error(err)
+		}
+
+		expectedResults := []int64{5, 20}
+		actualResults := make([]int64, 2)
+
+		for i, asyncResult := range asyncResults {
+			result, err := asyncResult.Get()
+			if err != nil {
+				t.Error(err)
+			}
+			intResult, ok := result.Interface().(int64)
+			if !ok {
+				t.Errorf("Could not convert %v to int64", result.Interface())
+			}
+			actualResults[i] = intResult
+		}
+
+		worker1.Quit()
+		worker2.Quit()
+
+		sort.Sort(ascendingInt64s(actualResults))
+
+		if !reflect.DeepEqual(expectedResults, actualResults) {
+			t.Errorf(
+				"expected results = %v, actual results = %v",
+				expectedResults,
+				actualResults,
+			)
+		}
+	}
+}

--- a/v1/brokers/eager.go
+++ b/v1/brokers/eager.go
@@ -23,6 +23,14 @@ type EagerMode interface {
 //
 // Broker interface
 //
+func (e *EagerBroker) SetRegisteredTaskNames(names []string) {
+	// do nothing
+}
+
+func (e *EagerBroker)  IsTaskRegistered(name string) bool {
+	return true
+}
+
 func (e *EagerBroker) StartConsuming(consumerTag string, p TaskProcessor) (bool, error) {
 	return true, nil
 }

--- a/v1/brokers/interfaces.go
+++ b/v1/brokers/interfaces.go
@@ -4,6 +4,8 @@ import "github.com/RichardKnop/machinery/v1/signatures"
 
 // Broker - a common interface for all brokers
 type Broker interface {
+	SetRegisteredTaskNames(names []string)
+	IsTaskRegistered(name string) bool
 	StartConsuming(consumerTag string, p TaskProcessor) (bool, error)
 	StopConsuming()
 	Publish(task *signatures.TaskSignature) error

--- a/v1/server.go
+++ b/v1/server.go
@@ -90,11 +90,19 @@ func (server *Server) SetConfig(cnf *config.Config) {
 // RegisterTasks registers all tasks at once
 func (server *Server) RegisterTasks(tasks map[string]interface{}) {
 	server.registeredTasks = tasks
+	server.broker.SetRegisteredTaskNames(server.getRegisteredTaskNames())
 }
 
 // RegisterTask registers a single task
 func (server *Server) RegisterTask(name string, task interface{}) {
 	server.registeredTasks[name] = task
+	server.broker.SetRegisteredTaskNames(server.getRegisteredTaskNames())
+}
+
+// IsTaskRegistered returns true if the task name is registered with this broker
+func (server *Server)  IsTaskRegistered(name string) bool {
+	_, ok := server.registeredTasks[name]
+	return ok
 }
 
 // GetRegisteredTask returns registered task by name
@@ -202,4 +210,14 @@ func (server *Server) SendChord(chord *Chord) (*backends.ChordAsyncResult, error
 		chord.Callback,
 		server.backend,
 	), nil
+}
+
+func (server *Server) getRegisteredTaskNames() []string {
+	names := make([]string, len(server.registeredTasks))
+
+	for name, _ := range server.registeredTasks {
+		names = append(names, name)
+	}
+
+	return names
 }

--- a/v1/server_test.go
+++ b/v1/server_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRegisterTasks(t *testing.T) {
-	server := getTestServer(t)
+	server := _getTestServer(t)
 	server.RegisterTasks(map[string]interface{}{
 		"test_task": func() {},
 	})
@@ -19,7 +19,7 @@ func TestRegisterTasks(t *testing.T) {
 }
 
 func TestRegisterTask(t *testing.T) {
-	server := getTestServer(t)
+	server := _getTestServer(t)
 	server.RegisterTask("test_task", func() {})
 
 	_, err := server.GetRegisteredTask("test_task")
@@ -29,13 +29,13 @@ func TestRegisterTask(t *testing.T) {
 }
 
 func TestGetRegisteredTask(t *testing.T) {
-	_, err := getTestServer(t).GetRegisteredTask("test_task")
+	_, err := _getTestServer(t).GetRegisteredTask("test_task")
 	if err == nil {
 		t.Error("test_task is registered but it should not be")
 	}
 }
 
-func getTestServer(t *testing.T) *Server {
+func _getTestServer(t *testing.T) *Server {
 	server, err := NewServer(&config.Config{
 		Broker:        "amqp://guest:guest@localhost:5672/",
 		ResultBackend: "redis://127.0.0.1:6379",


### PR DESCRIPTION
When there were two parallel workers running, worker 1 with registered
task A and worker 2 with registered task B and you sent a group with
tasks A and B, there was a bug when worker 2 could pick up the A task
and fail to consume it anv vice versa which could cause SendGroup ->
result.Get() to hang.

Added integration test for such case to avoid it in the future:
integrationtests/worker_only_consumes_registered_tasks_test.go