### PR TITLE
Ack a message after task was actually processed

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -164,11 +164,12 @@ func (amqpBroker *AMQPBroker) consumeOne(d amqp.Delivery, taskProcessor TaskProc
 		return
 	}
 
-	d.Ack(false) // multiple
 
 	if err := taskProcessor.Process(&signature); err != nil {
 		errorsChan <- err
 	}
+	
+	d.Ack(false) // multiple
 }
 
 // Consumes messages...


### PR DESCRIPTION
Currently Message is acknowledged before task was actually processed.
https://github.com/RichardKnop/machinery/blob/master/v1/brokers/amqp.go#L167

This contains potential message loose. Cause if task is not fully processed (f.e. worker process was killed) onError won't be called.

RabbitMQ [Reliability Guide](https://www.rabbitmq.com/reliability.html) also tips to acknowledge a message only after processing.