### PR TITLE
Allow Redis password

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Result backend to use for keeping task states and results.
 
 Currently supported backends are:
 
-* Redis (use Redis URL such as `redis://127.0.0.1:6379`)
+* Redis (use Redis URL such as `redis://127.0.0.1:6379`, or to use password `redis://password@127.0.0.1:6379`)
 * Memcache (use Memcache URL such as `memcache://10.0.0.1:11211,10.0.0.2:11211`)
 * AMQP (use AMQP URL such as `amqp://guest:guest@localhost:5672/`)
 

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -13,16 +13,18 @@ import (
 
 // RedisBackend represents a Memcache result backend
 type RedisBackend struct {
-	config *config.Config
-	host   string
-	conn   redis.Conn
+	config   *config.Config
+	host     string
+	password string
+	conn     redis.Conn
 }
 
 // NewRedisBackend creates RedisBackend instance
-func NewRedisBackend(cnf *config.Config, host string) Backend {
+func NewRedisBackend(cnf *config.Config, host, password string) Backend {
 	return Backend(&RedisBackend{
-		config: cnf,
-		host:   host,
+		config:   cnf,
+		host:     host,
+		password: password,
 	})
 }
 
@@ -278,5 +280,9 @@ func (redisBackend *RedisBackend) setExpirationTime(key string) error {
 
 // Returns / creates instance of Redis connection
 func (redisBackend *RedisBackend) open() (redis.Conn, error) {
+	if redisBackend.password != "" {
+		return redis.Dial("tcp", redisBackend.host,
+			redis.DialPassword(redisBackend.password))
+	}
 	return redis.Dial("tcp", redisBackend.host)
 }

--- a/v1/backends/redis_test.go
+++ b/v1/backends/redis_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestGroupCompletedRedis(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		return
 	}
@@ -25,7 +26,7 @@ func TestGroupCompletedRedis(t *testing.T) {
 		GroupUUID: groupUUID,
 	}
 
-	backend := NewRedisBackend(&config.Config{}, redisURL)
+	backend := NewRedisBackend(&config.Config{}, redisURL, redisPassword)
 
 	// Cleanup before the test
 	backend.PurgeState(task1.UUID)
@@ -70,6 +71,7 @@ func TestGroupCompletedRedis(t *testing.T) {
 
 func TestGetStateRedis(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		return
 	}
@@ -79,7 +81,7 @@ func TestGetStateRedis(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := NewRedisBackend(&config.Config{}, redisURL)
+	backend := NewRedisBackend(&config.Config{}, redisURL, redisPassword)
 
 	go func() {
 		backend.SetStatePending(signature)
@@ -110,6 +112,7 @@ func TestGetStateRedis(t *testing.T) {
 
 func TestPurgeStateRedis(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		return
 	}
@@ -119,7 +122,7 @@ func TestPurgeStateRedis(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := NewRedisBackend(&config.Config{}, redisURL)
+	backend := NewRedisBackend(&config.Config{}, redisURL, redisPassword)
 
 	backend.SetStatePending(signature)
 	taskState, err := backend.GetState(signature.UUID)

--- a/v1/factories.go
+++ b/v1/factories.go
@@ -24,7 +24,18 @@ func BrokerFactory(cnf *config.Config) (brokers.Broker, error) {
 				cnf.Broker,
 			)
 		}
-		return brokers.NewRedisBroker(cnf, parts[1]), nil
+
+		var redisHost, redisPassword string
+
+		parts = strings.Split(parts[1], "@")
+		if len(parts) == 2 {
+			redisHost = parts[1]
+			redisPassword = parts[0]
+		} else {
+			redisHost = parts[0]
+		}
+
+		return brokers.NewRedisBroker(cnf, redisHost, redisPassword), nil
 	}
 
 	if strings.HasPrefix(cnf.Broker, "eager") {
@@ -57,11 +68,22 @@ func BackendFactory(cnf *config.Config) (backends.Backend, error) {
 		parts := strings.Split(cnf.ResultBackend, "redis://")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf(
-				"Redis result backend connection string should be in format redis://host:port, instead got %s",
+				"Redis result backend connection string should be in format redis://password@host:port, instead got %s",
 				cnf.ResultBackend,
 			)
 		}
-		return backends.NewRedisBackend(cnf, parts[1]), nil
+
+		var redisHost, redisPassword string
+
+		parts = strings.Split(parts[1], "@")
+		if len(parts) == 2 {
+			redisHost = parts[1]
+			redisPassword = parts[0]
+		} else {
+			redisHost = parts[0]
+		}
+
+		return backends.NewRedisBackend(cnf, redisHost, redisPassword), nil
 	}
 
 	if strings.HasPrefix(cnf.ResultBackend, "eager") {

--- a/v1/factories_test.go
+++ b/v1/factories_test.go
@@ -35,6 +35,23 @@ func TestBrokerFactory(t *testing.T) {
 
 	// 1) Redis broker test
 
+	// with password
+	cnf = config.Config{
+		Broker:       "redis://password@localhost:6379",
+		DefaultQueue: "machinery_tasks",
+	}
+
+	actual, err = BrokerFactory(&cnf)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	expected = brokers.NewRedisBroker(&cnf, "localhost:6379", "password")
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("conn = %v, want %v", actual, expected)
+	}
+
+	// without password
 	cnf = config.Config{
 		Broker:       "redis://localhost:6379",
 		DefaultQueue: "machinery_tasks",
@@ -45,7 +62,7 @@ func TestBrokerFactory(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	expected = brokers.NewRedisBroker(&cnf, "localhost:6379")
+	expected = brokers.NewRedisBroker(&cnf, "localhost:6379", "")
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("conn = %v, want %v", actual, expected)
 	}
@@ -105,6 +122,23 @@ func TestBackendFactory(t *testing.T) {
 
 	// 2) Redis backend test
 
+	// with password
+	cnf = config.Config{
+		ResultBackend: "redis://password@localhost:6379",
+	}
+	actual, err = BackendFactory(&cnf)
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	expected = backends.NewRedisBackend(&cnf, "localhost:6379", "password")
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("conn = %v, want %v", actual, expected)
+	}
+
+	// without password
 	cnf = config.Config{
 		ResultBackend: "redis://localhost:6379",
 	}
@@ -114,7 +148,7 @@ func TestBackendFactory(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	expected = backends.NewRedisBackend(&cnf, "localhost:6379")
+	expected = backends.NewRedisBackend(&cnf, "localhost:6379", "")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("conn = %v, want %v", actual, expected)


### PR DESCRIPTION
Until now connecting to Redis server secured by a password was not
possible.

This PR adds an option to specify Redis broker / backend connection
string in a format `redis://password@127.0.0.1:6379`.