### PR TITLE
Mark the task as failed if reflection fails.

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -77,6 +77,7 @@ func (worker *Worker) Process(signature *signatures.TaskSignature) error {
 	reflectedTask := reflect.ValueOf(task)
 	relfectedArgs, err := worker.reflectArgs(signature.Args)
 	if err != nil {
+		worker.finalizeError(signature, err)
 		return fmt.Errorf("Reflect task args: %v", err)
 	}
 


### PR DESCRIPTION
If reflection fails for a given argument, mark the task as failed and return the error.
Fixes #56.

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>