### PR TITLE
Recover from task panics in worker.

### DIFF
--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -1,0 +1,34 @@
+package machinery
+
+import (
+	. "github.com/RichardKnop/machinery/v1/signatures"
+	"reflect"
+	"testing"
+)
+
+func TestInvalidArgRobustness(t *testing.T) {
+	// Create a func and reflect it
+	fValue := reflect.ValueOf(func(x int) {})
+
+	// Construct an invalid argument list and reflect it
+	args := []TaskArg{
+		TaskArg{"bool", true},
+	}
+
+	argValues, err := reflectArgs(args)
+	if err != nil {
+		t.Errorf("reflectArgs error = %v, want nil", err)
+	}
+
+	// Invoke tryCall and validate error handling
+	results, err := tryCall(fValue, argValues)
+
+	expectedMessage := "reflect: Call using bool as type int"
+	if err.Error() != expectedMessage {
+		t.Errorf("tryCall error = %v, want %v", err, expectedMessage)
+	}
+
+	if results != nil {
+		t.Errorf("results = %v, want nil", results)
+	}
+}


### PR DESCRIPTION
This patch makes the worker more robust to malformed input (argument list length, mismatched types, etc.)  My rationale was that these panics are solely the result of bad requests from some other domain, and there's a clear recovery path that feels better than letting the worker process crash.

Looking forward to your feedback!

Testing done:

- `$ go test -v -run TestInvalidArgRobustness ./v1`
- `$ make test`