### PR TITLE
Use gofmt tool instead of 'go fmt'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install-deps:
 	$(DEPS) | xargs -n1 go get -d
 
 fmt:
-	bash -c 'go list ./... | grep -v vendor | xargs -n1 go fmt'
+	bash -c 'git ls-files "**.go" | grep -v ^vendor/ | xargs -n1 gofmt -e -s -w'
 
 test:
 	bash -c 'go list ./... | grep -v vendor | xargs -n1 go test -timeout=30s'

--- a/examples/send/send.go
+++ b/examples/send/send.go
@@ -54,11 +54,11 @@ func initTasks() {
 	task0 = signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 1,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 1,
 			},
@@ -68,11 +68,11 @@ func initTasks() {
 	task1 = signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 2,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 2,
 			},
@@ -82,11 +82,11 @@ func initTasks() {
 	task2 = signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 5,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 6,
 			},
@@ -96,7 +96,7 @@ func initTasks() {
 	task3 = signatures.TaskSignature{
 		Name: "multiply",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 4,
 			},

--- a/integrationtests/eager_eager_test.go
+++ b/integrationtests/eager_eager_test.go
@@ -53,7 +53,7 @@ func (s *EagerIntegrationTestSuite) TestCalled() {
 	_, err := s.srv.SendTask(&signatures.TaskSignature{
 		Name: "float_called",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: 100.0,
 			},
@@ -70,7 +70,7 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 		result, err := s.srv.SendTask(&signatures.TaskSignature{
 			Name: "float_result",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "float64",
 					Value: 100.0,
 				},
@@ -97,7 +97,7 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 		result, err := s.srv.SendTask(&signatures.TaskSignature{
 			Name: "int_result",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 100,
 				},

--- a/integrationtests/testutils.go
+++ b/integrationtests/testutils.go
@@ -21,11 +21,11 @@ func _getTasks() []signatures.TaskSignature {
 	task0 := signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 1,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 1,
 			},
@@ -35,11 +35,11 @@ func _getTasks() []signatures.TaskSignature {
 	task1 := signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 2,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 2,
 			},
@@ -49,11 +49,11 @@ func _getTasks() []signatures.TaskSignature {
 	task2 := signatures.TaskSignature{
 		Name: "add",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 5,
 			},
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 6,
 			},
@@ -63,7 +63,7 @@ func _getTasks() []signatures.TaskSignature {
 	task3 := signatures.TaskSignature{
 		Name: "multiply",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "int64",
 				Value: 4,
 			},

--- a/integrationtests/worker_only_consumes_registered_tasks_test.go
+++ b/integrationtests/worker_only_consumes_registered_tasks_test.go
@@ -51,11 +51,11 @@ func TestWorkerOnlyConsumesRegisteredTaskAMQP(t *testing.T) {
 		task1 := signatures.TaskSignature{
 			Name: "add",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 2,
 				},
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 3,
 				},
@@ -65,11 +65,11 @@ func TestWorkerOnlyConsumesRegisteredTaskAMQP(t *testing.T) {
 		task2 := signatures.TaskSignature{
 			Name: "multiply",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 4,
 				},
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 5,
 				},
@@ -155,11 +155,11 @@ func TestWorkerOnlyConsumesRegisteredTaskRedis(t *testing.T) {
 		task1 := signatures.TaskSignature{
 			Name: "add",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 2,
 				},
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 3,
 				},
@@ -169,11 +169,11 @@ func TestWorkerOnlyConsumesRegisteredTaskRedis(t *testing.T) {
 		task2 := signatures.TaskSignature{
 			Name: "multiply",
 			Args: []signatures.TaskArg{
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 4,
 				},
-				signatures.TaskArg{
+				{
 					Type:  "int64",
 					Value: 5,
 				},

--- a/v1/backends/eager_test.go
+++ b/v1/backends/eager_test.go
@@ -24,12 +24,12 @@ func (s *EagerBackendTestSuite) SetupSuite() {
 
 	// 2 non-group state
 	s.st = []*signatures.TaskSignature{
-		&signatures.TaskSignature{UUID: "1"},
-		&signatures.TaskSignature{UUID: "2"},
-		&signatures.TaskSignature{UUID: "3"},
-		&signatures.TaskSignature{UUID: "4"},
-		&signatures.TaskSignature{UUID: "5"},
-		&signatures.TaskSignature{UUID: "6"},
+		{UUID: "1"},
+		{UUID: "2"},
+		{UUID: "3"},
+		{UUID: "4"},
+		{UUID: "5"},
+		{UUID: "6"},
 	}
 
 	for _, t := range s.st {

--- a/v1/server.go
+++ b/v1/server.go
@@ -215,7 +215,7 @@ func (server *Server) SendChord(chord *Chord) (*backends.ChordAsyncResult, error
 func (server *Server) getRegisteredTaskNames() []string {
 	names := make([]string, len(server.registeredTasks))
 
-	for name, _ := range server.registeredTasks {
+	for name := range server.registeredTasks {
 		names = append(names, name)
 	}
 

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -166,7 +166,7 @@ func (worker *Worker) finalizeSuccess(signature *signatures.TaskSignature, resul
 	for _, successTask := range signature.OnSuccess {
 		if signature.Immutable == false {
 			// Pass results of the task to success callbacks
-			args := append([]signatures.TaskArg{signatures.TaskArg{
+			args := append([]signatures.TaskArg{{
 				Type:  taskResult.Type,
 				Value: taskResult.Value,
 			}}, successTask.Args...)
@@ -243,7 +243,7 @@ func (worker *Worker) finalizeError(signature *signatures.TaskSignature, err err
 	// Trigger error callbacks
 	for _, errorTask := range signature.OnError {
 		// Pass error as a first argument to error callbacks
-		args := append([]signatures.TaskArg{signatures.TaskArg{
+		args := append([]signatures.TaskArg{{
 			Type:  reflect.TypeOf(err).String(),
 			Value: reflect.ValueOf(err).Interface(),
 		}}, errorTask.Args...)

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -13,7 +13,7 @@ func TestInvalidArgRobustness(t *testing.T) {
 
 	// Construct an invalid argument list and reflect it
 	args := []TaskArg{
-		TaskArg{"bool", true},
+		{"bool", true},
 	}
 
 	argValues, err := reflectArgs(args)

--- a/v1/workflow_test.go
+++ b/v1/workflow_test.go
@@ -10,11 +10,11 @@ func TestNewChain(t *testing.T) {
 	task1 := signatures.TaskSignature{
 		Name: "foo",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: interface{}(1),
 			},
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: interface{}(1),
 			},
@@ -24,11 +24,11 @@ func TestNewChain(t *testing.T) {
 	task2 := signatures.TaskSignature{
 		Name: "bar",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: interface{}(5),
 			},
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: interface{}(6),
 			},
@@ -38,7 +38,7 @@ func TestNewChain(t *testing.T) {
 	task3 := signatures.TaskSignature{
 		Name: "qux",
 		Args: []signatures.TaskArg{
-			signatures.TaskArg{
+			{
 				Type:  "float64",
 				Value: interface{}(4),
 			},


### PR DESCRIPTION
Also ran updated `make fmt` target. Gofmt with the `-s` (simplify) option likes to elide struct names that can be inferred by the compiler, e.g. in slice literals.