### PR TITLE
Bug fix for error handling in worker

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -36,12 +36,12 @@ func (worker *Worker) Launch() error {
 	go func() {
 		for {
 			retry, err := broker.StartConsuming(worker.ConsumerTag, worker)
+			if err != nil {
+				errorsChan <- err
+			}
 
 			if retry {
 				log.Printf("Going to retry launching the worker. Error: %v", err)
-			} else {
-				errorsChan <- err // stop the goroutine
-				return
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #75 

Previously `broker.StartConsuming()` was able to kill the process due to a connection error.
Fix handles err and returns it to error channel.