### PR TITLE
Amqp broker: correct defer channel.Close()

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -51,7 +51,9 @@ func (amqpBroker *AMQPBroker) StartConsuming(consumerTag string, taskProcessor T
 	}
 
 	_, channel, queue, _, err := amqpBroker.open()
-	defer channel.Close()
+	if channel != nil {
+		defer channel.Close()
+	}
 	if err != nil {
 		amqpBroker.retryFunc()
 		return amqpBroker.retry, err // retry true


### PR DESCRIPTION
Brocker amqp.open() return nil channel if amqp.DialTLS() return not empty err:
```
// Connects to the message queue, opens a channel, declares a queue
func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queue, <-chan amqp.Confirmation, error) {
	var (
		conn    *amqp.Connection
		channel *amqp.Channel
		queue   amqp.Queue
		err     error
	)

	// Connect
	// From amqp docs: DialTLS will use the provided tls.Config when it encounters an amqps:// scheme
	// and will dial a plain connection when it encounters an amqp:// scheme.
	conn, err = amqp.DialTLS(amqpBroker.config.Broker, amqpBroker.config.TLSConfig)

	if err != nil {
		return conn, channel, queue, nil, fmt.Errorf("Dial: %s", err)
	}
```
Then this will throw panic: runtime error: nil pointer dereference:
```
// StartConsuming enters a loop and waits for incoming messages
func (amqpBroker *AMQPBroker) StartConsuming(consumerTag string, taskProcessor TaskProcessor) (bool, error) {

	<...>

	_, channel, queue, _, err := amqpBroker.open()
->  defer channel.Close()
```