### PR TITLE
Avoid hammering and configure timeouts

### DIFF
--- a/v1/backends/result.go
+++ b/v1/backends/result.go
@@ -3,6 +3,7 @@ package backends
 import (
 	"errors"
 	"reflect"
+	"time"
 
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/RichardKnop/machinery/v1/utils"
@@ -88,6 +89,42 @@ func (asyncResult *AsyncResult) Get() (reflect.Value, error) {
 			return reflect.Value{}, errors.New(asyncResult.taskState.Error)
 		}
 	}
+}
+
+// Get returns task result limited in time(synchronous blocking call)
+func (asyncResult *AsyncResult) GetWithTimeout(timeoutD, sleepD time.Duration) (reflect.Value, error) {
+       if asyncResult.backend == nil {
+               return reflect.Value{}, errors.New("Result backend not configured")
+       }
+
+       timeout := time.NewTimer(timeoutD)
+
+	for {
+               select {
+               case <-timeout.C:
+                       return reflect.Value{}, errors.New("Timeout reached")
+               default:
+                       asyncResult.GetState()
+
+                       // Purge state if we are using AMQP backend
+                       _, isAMQPBackend := asyncResult.backend.(*AMQPBackend)
+                       if isAMQPBackend && asyncResult.taskState.IsCompleted() {
+                               asyncResult.backend.PurgeState(asyncResult.taskState.TaskUUID)
+                       }
+
+                       if asyncResult.taskState.IsSuccess() {
+                               return utils.ReflectValue(
+                                       asyncResult.taskState.Result.Type,
+                                       asyncResult.taskState.Result.Value,
+                               )
+                       }
+
+                       if asyncResult.taskState.IsFailure() {
+                               return reflect.Value{}, errors.New(asyncResult.taskState.Error)
+                       }
+                       time.Sleep(sleepD)
+               }
+       }
 }
 
 // GetState returns latest task state


### PR DESCRIPTION
With the added code, you can request the result but define also in what time that you expect the result to be ready and also the retry interval to check the status.