### PR TITLE
Task Redirection By Headers

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -125,7 +125,7 @@ func (amqpBroker *AMQPBroker) Publish(signature *signatures.TaskSignature) error
 		false,                      // mandatory
 		false,                      // immediate
 		amqp.Publishing{
-			Headers:      signature.Headers,
+			Headers:      amqp.Table(signature.Headers),
 			ContentType:  "application/json",
 			Body:         message,
 			DeliveryMode: amqp.Persistent,
@@ -254,7 +254,7 @@ func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queu
 		amqpBroker.config.BindingKey, // binding key
 		amqpBroker.config.Exchange,   // source exchange
 		false, // noWait
-		amqpBroker.config.QueueArguments, // arguments
+		amqp.Table(amqpBroker.config.QueueBindingArguments), // arguments
 	); err != nil {
 		return conn, channel, queue, nil, fmt.Errorf("Queue Bind: %s", err)
 	}

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -125,6 +125,7 @@ func (amqpBroker *AMQPBroker) Publish(signature *signatures.TaskSignature) error
 		false,                      // mandatory
 		false,                      // immediate
 		amqp.Publishing{
+			Headers:      signature.Headers,
 			ContentType:  "application/json",
 			Body:         message,
 			DeliveryMode: amqp.Persistent,
@@ -253,7 +254,7 @@ func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queu
 		amqpBroker.config.BindingKey, // binding key
 		amqpBroker.config.Exchange,   // source exchange
 		false, // noWait
-		nil,   // arguments
+		amqpBroker.config.QueueArguments, // arguments
 	); err != nil {
 		return conn, channel, queue, nil, fmt.Errorf("Queue Bind: %s", err)
 	}

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -10,13 +10,14 @@ import (
 
 // Config holds all configuration for our program
 type Config struct {
-	Broker          string `yaml:"broker"`
-	ResultBackend   string `yaml:"result_backend"`
-	ResultsExpireIn int    `yaml:"results_expire_in"`
-	Exchange        string `yaml:"exchange"`
-	ExchangeType    string `yaml:"exchange_type"`
-	DefaultQueue    string `yaml:"default_queue"`
-	BindingKey      string `yaml:"binding_key"`
+	Broker          string                 `yaml:"broker"`
+	ResultBackend   string                 `yaml:"result_backend"`
+	ResultsExpireIn int                    `yaml:"results_expire_in"`
+	Exchange        string                 `yaml:"exchange"`
+	ExchangeType    string                 `yaml:"exchange_type"`
+	DefaultQueue    string                 `yaml:"default_queue"`
+	QueueArguments  map[string]interface{} `yaml:"queue_arguments"`
+	BindingKey      string                 `yaml:"binding_key"`
 	TLSConfig       *tls.Config
 }
 

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -8,17 +8,20 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// QueueBindingArguments arguments which are used when binding to the exchange
+type QueueBindingArguments map[string]interface{}
+
 // Config holds all configuration for our program
 type Config struct {
-	Broker          string                 `yaml:"broker"`
-	ResultBackend   string                 `yaml:"result_backend"`
-	ResultsExpireIn int                    `yaml:"results_expire_in"`
-	Exchange        string                 `yaml:"exchange"`
-	ExchangeType    string                 `yaml:"exchange_type"`
-	DefaultQueue    string                 `yaml:"default_queue"`
-	QueueArguments  map[string]interface{} `yaml:"queue_arguments"`
-	BindingKey      string                 `yaml:"binding_key"`
-	TLSConfig       *tls.Config
+	Broker                string                `yaml:"broker"`
+	ResultBackend         string                `yaml:"result_backend"`
+	ResultsExpireIn       int                   `yaml:"results_expire_in"`
+	Exchange              string                `yaml:"exchange"`
+	ExchangeType          string                `yaml:"exchange_type"`
+	DefaultQueue          string                `yaml:"default_queue"`
+	QueueBindingArguments QueueBindingArguments `yaml:"queue_binding_arguments"`
+	BindingKey            string                `yaml:"binding_key"`
+	TLSConfig             *tls.Config
 }
 
 // ReadFromFile reads data from a file

--- a/v1/config/config_test.go
+++ b/v1/config/config_test.go
@@ -16,6 +16,9 @@ results_expire_in: 3600000
 exchange: machinery_exchange
 exchange_type: direct
 default_queue: machinery_tasks
+queue_binding_arguments:
+  image-type: png
+  x-match: any
 binding_key: machinery_task
 `
 
@@ -46,4 +49,6 @@ func TestParseYAMLConfig(t *testing.T) {
 	assert.Equal(t, "direct", cfg.ExchangeType)
 	assert.Equal(t, "machinery_tasks", cfg.DefaultQueue)
 	assert.Equal(t, "machinery_task", cfg.BindingKey)
+	assert.Equal(t, "any", cfg.QueueBindingArguments["x-match"])
+	assert.Equal(t, "png", cfg.QueueBindingArguments["image-type"])
 }

--- a/v1/config/testconfig.yml
+++ b/v1/config/testconfig.yml
@@ -5,4 +5,7 @@ results_expire_in: 3600000
 exchange: machinery_exchange
 exchange_type: direct
 default_queue: machinery_tasks
+queue_binding_arguments:
+  image-type: png
+  x-match: any
 binding_key: machinery_task

--- a/v1/signatures/signatures.go
+++ b/v1/signatures/signatures.go
@@ -14,6 +14,7 @@ type TaskSignature struct {
 	GroupUUID      string
 	GroupTaskCount int
 	Args           []TaskArg
+	Headers        map[string]interface{}
 	Immutable      bool
 	OnSuccess      []*TaskSignature
 	OnError        []*TaskSignature

--- a/v1/signatures/signatures.go
+++ b/v1/signatures/signatures.go
@@ -6,6 +6,9 @@ type TaskArg struct {
 	Value interface{}
 }
 
+// TaskHeaders represents the headers which should be used to direct the task
+type TaskHeaders map[string]interface{}
+
 // TaskSignature represents a single task invocation
 type TaskSignature struct {
 	UUID           string
@@ -14,7 +17,7 @@ type TaskSignature struct {
 	GroupUUID      string
 	GroupTaskCount int
 	Args           []TaskArg
-	Headers        map[string]interface{}
+	Headers        TaskHeaders
 	Immutable      bool
 	OnSuccess      []*TaskSignature
 	OnError        []*TaskSignature


### PR DESCRIPTION
Support added to allow tasks to be redirected to a queue using task headers(Exchange type Headers). Celery sort of hand this feature(Very undocumented).

Use case want to send task to a worker running in a region/pool of workers.

Still todo

- [x] Update Tests
- [x] Code Cleanup

This has been issued for any discussion,

Currently use `map[string]interface{}` as the header type as it matches the type of Amqp.Table, thinking of typing this to machinery.Headers
