### PR TITLE
Support for connecting to Redis socket file

### DIFF
--- a/integrationtests/redis_socket_test.go
+++ b/integrationtests/redis_socket_test.go
@@ -1,0 +1,23 @@
+package integrationtests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestRedisSocket(t *testing.T) {
+	redisSocket := os.Getenv("REDIS_SOCKET")
+
+	if redisSocket != "" {
+		// Redis broker, Redis result backend
+		server := _setup(fmt.Sprintf("redis+socket://%v", redisSocket), fmt.Sprintf("redis+socket://%v", redisSocket))
+		worker := server.NewWorker("test_worker")
+		go worker.Launch()
+		_testSendTask(server, t)
+		_testSendGroup(server, t)
+		_testSendChord(server, t)
+		_testSendChain(server, t)
+		worker.Quit()
+	}
+}

--- a/v1/backends/redis_test.go
+++ b/v1/backends/redis_test.go
@@ -28,7 +28,7 @@ func TestGroupCompletedRedis(t *testing.T) {
 		GroupUUID: groupUUID,
 	}
 
-	backend := backends.NewRedisBackend(&config.Config{}, redisURL, redisPassword, 0)
+	backend := backends.NewRedisBackend(&config.Config{}, redisURL, redisPassword, "", 0)
 
 	// Cleanup before the test
 	backend.PurgeState(task1.UUID)
@@ -82,7 +82,7 @@ func TestGetStateRedis(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := backends.NewRedisBackend(new(config.Config), redisURL, redisPassword, 0)
+	backend := backends.NewRedisBackend(new(config.Config), redisURL, redisPassword, "", 0)
 
 	go func() {
 		backend.SetStatePending(signature)
@@ -128,7 +128,7 @@ func TestPurgeStateRedis(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := backends.NewRedisBackend(new(config.Config), redisURL, redisPassword, 0)
+	backend := backends.NewRedisBackend(new(config.Config), redisURL, redisPassword, "", 0)
 
 	backend.SetStatePending(signature)
 	taskState, err := backend.GetState(signature.UUID)


### PR DESCRIPTION
Per #89, here is support for connecting to Redis over a Unix domain socket. The approach taken here is a new URI scheme, meant as more of a stepping stone until the `Config` object allows finer-grained control over backend/broker connections.

I found various URI formats for Redis-over-socket in other projects, all slightly different, so there doesn't seem to be a standard by which to abide per se. See these for comparison or inspiration:

- https://github.com/mp911de/lettuce/wiki/Redis-URI-and-connection-details
- https://metacpan.org/pod/URI::redis
- http://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html

Here I went with `redis+socket:// [passwd@] /path/to/file.sock [:/db_num]`, whereas some other projects have made use of query parameters.

I tried not to touch public function signatures, but adding support without changing `NewRedisBackend/Broker` was very ugly and unreliable. It was tricky since there are a few different ways to instantiate backends/brokers, given the number of exported package items. Because of this, the `NewRedis*` funcs now takes a socket file argument, which can be blank.

I added a couple tests, but the Travis CI config does not test using a socket file.

Let me know what you think! I'd be glad to make improvements or fix any errors you catch. Looking forward to working with ya on a merge.