### PR TITLE
Pluggable Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ So called tasks (or jobs if you like) are executed concurrently either by many w
 
 * [First Steps](#first-steps)
 * [Configuration](#configuration)
+* [Custom Logger](custom-logger)
 * [Server](#server)
 * [Workers](#workers)
 * [Tasks](#tasks)
@@ -70,7 +71,7 @@ type QueueBindingArguments map[string]interface{}
 
 // Config holds all configuration for our program
 type Config struct {
-    Broker                string                `yaml:"broker"`
+  Broker                string                `yaml:"broker"`
 	ResultBackend         string                `yaml:"result_backend"`
 	ResultsExpireIn       int                   `yaml:"results_expire_in"`
 	Exchange              string                `yaml:"exchange"`
@@ -87,26 +88,26 @@ type Config struct {
 
 A message broker. Currently supported brokers are:
 
-#### AMQP 
+#### AMQP
 
-Use AMQP URL in the format: 
+Use AMQP URL in the format:
 
-````
+```
 amqp://[username:password@]@host[:port]
-``` 
+```
 
 For example:
 
 1. `amqp://guest:guest@localhost:5672`
 
-#### Redis 
+#### Redis
 
-Use Redis URL in one of these formats: 
+Use Redis URL in one of these formats:
 
 ```
 redis://[password@]host[port][/db_num]
 redis+socket://[password@]/path/to/file.sock[:/db_num]
-``` 
+```
 
 For example:
 
@@ -119,40 +120,40 @@ Result backend to use for keeping task states and results.
 
 Currently supported backends are:
 
-#### Redis 
+#### Redis
 
-Use Redis URL in one of these formats: 
+Use Redis URL in one of these formats:
 
 ```
 redis://[password@]host[port][/db_num]
 redis+socket://[password@]/path/to/file.sock[:/db_num]
-``` 
+```
 
 For example:
 
 1. `redis://127.0.0.1:6379`, or with password `redis://password@127.0.0.1:6379`
 2. `redis+socket://password@/path/to/file.sock:/0`
 
-#### Memcache 
+#### Memcache
 
 Use Memcache URL in the format:
 
 ```
 memcache://host1[:port1][,host2[:port2],...[,hostN[:portN]]]
-``` 
+```
 
 For example:
 
-1. `memcache://127.0.0.1:11211` for a single instance, or 
+1. `memcache://127.0.0.1:11211` for a single instance, or
 2. `memcache://10.0.0.1:11211,10.0.0.2:11211` for a cluster
 
-#### AMQP 
+#### AMQP
 
-Use AMQP URL in the format: 
+Use AMQP URL in the format:
 
-````
+```
 amqp://[username:password@]@host[:port]
-``` 
+```
 
 For example:
 
@@ -160,13 +161,13 @@ For example:
 
 > Keep in mind AMQP is not recommended as a result backend. See [Keeping Results](https://github.com/RichardKnop/machinery#keeping-results)
 
-#### MongoDB 
+#### MongoDB
 
-Use Mongodb URL in the format: 
+Use Mongodb URL in the format:
 
 ```
 mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
-``` 
+```
 
 For example:
 
@@ -198,28 +199,54 @@ An optional map of additional arguments used when binding to an AMQP queue.
 
 The queue is bind to the exchange with this key, e.g. `machinery_task`. Only required for AMQP.
 
+## Custom Logger
+
+You can define a custom logger by implementing the following interface:
+
+```go
+type Interface interface {
+  Print(...interface{})
+  Printf(string, ...interface{})
+  Println(...interface{})
+
+  Fatal(...interface{})
+  Fatalf(string, ...interface{})
+  Fatalln(...interface{})
+
+  Panic(...interface{})
+  Panicf(string, ...interface{})
+  Panicln(...interface{})
+}
+```
+
+Then just set the logger in your setup code by calling `Set` function exported by `github.com/RichardKnop/machinery/logger` package:
+
+```go
+logger.Set(myCustomLogger)
+```
+
 ## Server
 
 A Machinery library must be instantiated before use. The way this is done is by creating a `Server` instance. `Server` is a base object which stores Machinery configuration and registered tasks. E.g.:
 
 ```go
 import (
-    "github.com/RichardKnop/machinery/v1/config"
-    machinery "github.com/RichardKnop/machinery/v1"
+  "github.com/RichardKnop/machinery/v1/config"
+  machinery "github.com/RichardKnop/machinery/v1"
 )
 
 var cnf = config.Config{
-    Broker:        "amqp://guest:guest@localhost:5672/",
-    ResultBackend: "amqp://guest:guest@localhost:5672/",
-    Exchange:      "machinery_exchange",
-    ExchangeType:  "direct",
-    DefaultQueue:  "machinery_tasks",
-    BindingKey:    "machinery_task",
+  Broker:        "amqp://guest:guest@localhost:5672/",
+  ResultBackend: "amqp://guest:guest@localhost:5672/",
+  Exchange:      "machinery_exchange",
+  ExchangeType:  "direct",
+  DefaultQueue:  "machinery_tasks",
+  BindingKey:    "machinery_task",
 }
 
 server, err := machinery.NewServer(&cnf)
 if err != nil {
-    // do something with the error
+  // do something with the error
 }
 ```
 
@@ -231,7 +258,7 @@ In order to consume tasks, you need to have one or more workers running. All you
 worker := server.NewWorker("worker_name")
 err := worker.Launch()
 if err != nil {
-    // do something with the error
+  // do something with the error
 }
 ```
 
@@ -239,7 +266,7 @@ Each worker will only consume registered tasks.
 
 ## Tasks
 
-Tasks are a building block of Machinery applications. A task is a function which defines what happens when a worker receives a message. 
+Tasks are a building block of Machinery applications. A task is a function which defines what happens when a worker receives a message.
 
 Currently each task needs to return two values, second one being `error`.
 
@@ -247,19 +274,19 @@ Let's say we want to define tasks for adding and multiplying numbers:
 
 ```go
 func Add(args ...int64) (int64, error) {
-    sum := int64(0)
-    for _, arg := range args {
-        sum += arg
-    }
-    return sum, nil
+  sum := int64(0)
+  for _, arg := range args {
+    sum += arg
+  }
+  return sum, nil
 }
 
 func Multiply(args ...int64) (int64, error) {
-    sum := int64(1)
-    for _, arg := range args {
-        sum *= arg
-    }
-    return sum, nil
+  sum := int64(1)
+  for _, arg := range args {
+    sum *= arg
+  }
+  return sum, nil
 }
 ```
 
@@ -269,8 +296,8 @@ Before your workers can consume a task, you need to register it with the server.
 
 ```go
 server.RegisterTasks(map[string]interface{}{
-    "add":      Add,
-    "multiply": Multiply,
+  "add":      Add,
+  "multiply": Multiply,
 })
 ```
 
@@ -285,25 +312,25 @@ Simply put, when a worker receives a message like this:
 
 ```json
 {
-    "UUID": "48760a1a-8576-4536-973b-da09048c2ac5",
-    "Name": "add",
-    "RoutingKey": "",
-    "GroupUUID": "",
-    "GroupTaskCount": 0,
-    "Args": [
-        {
-            "Type": "int64",
-            "Value": 1,
-        },
-        {
-            "Type": "int64",
-            "Value": 1,
-        }
-    ],
-    "Immutable": false,
-    "OnSuccess": null,
-    "OnError": null,
-    "ChordCallback": null
+  "UUID": "48760a1a-8576-4536-973b-da09048c2ac5",
+  "Name": "add",
+  "RoutingKey": "",
+  "GroupUUID": "",
+  "GroupTaskCount": 0,
+  "Args": [
+    {
+      "Type": "int64",
+      "Value": 1,
+    },
+    {
+      "Type": "int64",
+      "Value": 1,
+    }
+  ],
+  "Immutable": false,
+  "OnSuccess": null,
+  "OnError": null,
+  "ChordCallback": null
 }
 ```
 
@@ -386,27 +413,27 @@ Tasks can be called by passing an instance of `TaskSignature` to an `Server` ins
 
 ```go
 import (
-    "github.com/RichardKnop/machinery/v1/signatures"
+  "github.com/RichardKnop/machinery/v1/signatures"
 )
 
 task := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
+    },
+  },
 }
 
 asyncResult, err := server.SendTask(&task1)
 if err != nil {
-    // failed to send the task
-    // do something with the error
+  // failed to send the task
+  // do something with the error
 }
 
 ```
@@ -427,11 +454,11 @@ If you configure a result backend, the task states and results will be persisted
 
 ```go
 const (
-    PendingState  = "PENDING"
-    ReceivedState = "RECEIVED"
-    StartedState  = "STARTED"
-    SuccessState  = "SUCCESS"
-    FailureState  = "FAILURE"
+  PendingState  = "PENDING"
+  ReceivedState = "RECEIVED"
+  StartedState  = "STARTED"
+  SuccessState  = "SUCCESS"
+  FailureState  = "FAILURE"
 )
 ```
 
@@ -489,8 +516,8 @@ You can also do a synchronous blocking call to wait for a task result:
 ```go
 result, err := asyncResult.Get()
 if err != nil {
-    // getting result of a task failed
-    // do something with the error
+  // getting result of a task failed
+  // do something with the error
 }
 fmt.Println(result.Interface())
 ```
@@ -505,43 +532,43 @@ Running a single asynchronous task is fine but often you will want to design a w
 
 ```go
 import (
-    "github.com/RichardKnop/machinery/v1/signatures"
-    machinery "github.com/RichardKnop/machinery/v1"
+  "github.com/RichardKnop/machinery/v1/signatures"
+  machinery "github.com/RichardKnop/machinery/v1"
 )
 
 task1 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
+    },
+  },
 }
 
 task2 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
+    },
+  },
 }
 
 group := machinery.NewGroup(&task1, &task2)
 asyncResults, err := server.SendGroup(group)
 if err != nil {
-    // failed to send the group
-    // do something with the error
+  // failed to send the group
+  // do something with the error
 }
 ```
 
@@ -549,12 +576,12 @@ if err != nil {
 
 ```go
 for _, asyncResult := range asyncResults {
-    result, err := asyncResult.Get()
-    if err != nil {
-        // getting result of a task failed
-        // do something with the error
-    }
-    fmt.Println(result.Interface())
+  result, err := asyncResult.Get()
+  if err != nil {
+    // getting result of a task failed
+    // do something with the error
+  }
+  fmt.Println(result.Interface())
 }
 ```
 
@@ -564,48 +591,48 @@ for _, asyncResult := range asyncResults {
 
 ```go
 import (
-    "github.com/RichardKnop/machinery/v1/signatures"
-    machinery "github.com/RichardKnop/machinery/v1"
+  "github.com/RichardKnop/machinery/v1/signatures"
+  machinery "github.com/RichardKnop/machinery/v1"
 )
 
 task1 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
+    },
+  },
 }
 
 task2 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
+    },
+  },
 }
 
 task3 := signatures.TaskSignature{
-    Name: "multiply",
+  Name: "multiply",
 }
 
 group := machinery.NewGroup(&task1, &task2)
 chord := machinery.NewChord(group, &task3)
 chordAsyncResult, err := server.SendChord(chord)
 if err != nil {
-    // failed to send the chord
-    // do something with the error
+  // failed to send the chord
+  // do something with the error
 }
 ```
 
@@ -626,8 +653,8 @@ More explicitly:
 ```go
 result, err := chordAsyncResult.Get()
 if err != nil {
-    // getting result of a chord failed
-    // do something with the error
+  // getting result of a chord failed
+  // do something with the error
 }
 fmt.Println(result.Interface())
 ```
@@ -638,53 +665,53 @@ fmt.Println(result.Interface())
 
 ```go
 import (
-    "github.com/RichardKnop/machinery/v1/signatures"
-    machinery "github.com/RichardKnop/machinery/v1"
+  "github.com/RichardKnop/machinery/v1/signatures"
+  machinery "github.com/RichardKnop/machinery/v1"
 )
 
 task1 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 1,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 1,
+    },
+  },
 }
 
 task2 := signatures.TaskSignature{
-    Name: "add",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 5,
-        },
+  Name: "add",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
     },
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 5,
+    },
+  },
 }
 
 task3 := signatures.TaskSignature{
-    Name: "multiply",
-    Args: []signatures.TaskArg{
-        signatures.TaskArg{
-            Type:  "int64",
-            Value: 4,
-        },
+  Name: "multiply",
+  Args: []signatures.TaskArg{
+    signatures.TaskArg{
+      Type:  "int64",
+      Value: 4,
     },
+  },
 }
 
 chain := machinery.NewChain(&task1, &task2, &task3)
 chainAsyncResult, err := server.SendChain(chain)
 if err != nil {
-    // failed to send the chain
-    // do something with the error
+  // failed to send the chain
+  // do something with the error
 }
 ```
 
@@ -705,8 +732,8 @@ More explicitly:
 ```go
 result, err := chainAsyncResult.Get()
 if err != nil {
-    // getting result of a chain failed
-    // do something with the error
+  // getting result of a chain failed
+  // do something with the error
 }
 fmt.Println(result.Interface())
 ```

--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/logger"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/streadway/amqp"
 )
@@ -177,8 +177,8 @@ func (amqpBackend *AMQPBackend) GetState(taskUUID string) (*TaskState, error) {
 	d.Ack(false)
 
 	if err := json.Unmarshal([]byte(d.Body), taskState); err != nil {
-		log.Printf("Failed to unmarshal task state: %v", string(d.Body))
-		log.Print(err)
+		logger.Get().Printf("Failed to unmarshal task state: %v", string(d.Body))
+		logger.Get().Print(err)
 		return nil, err
 	}
 

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -3,10 +3,10 @@ package backends
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/logger"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/garyburd/redigo/redis"
 )
@@ -186,8 +186,8 @@ func (redisBackend *RedisBackend) getGroupMeta(groupUUID string) (*GroupMeta, er
 func (redisBackend *RedisBackend) getStates(taskUUIDs ...string) ([]*TaskState, error) {
 	taskStates := make([]*TaskState, len(taskUUIDs))
 
-	log.Print("Getting states")
-	log.Print(taskUUIDs)
+	logger.Get().Print("Getting states")
+	logger.Get().Print(taskUUIDs)
 
 	conn := redisBackend.open()
 	defer conn.Close()
@@ -211,7 +211,7 @@ func (redisBackend *RedisBackend) getStates(taskUUIDs ...string) ([]*TaskState, 
 
 		taskState := new(TaskState)
 		if err := json.Unmarshal(bytes, taskState); err != nil {
-			log.Print(err)
+			logger.Get().Print(err)
 			return taskStates, err
 		}
 

--- a/v1/backends/result.go
+++ b/v1/backends/result.go
@@ -91,7 +91,7 @@ func (asyncResult *AsyncResult) Get() (reflect.Value, error) {
 	}
 }
 
-// Get returns task result limited in time(synchronous blocking call)
+// GetWithTimeout returns task result limited in time(synchronous blocking call)
 func (asyncResult *AsyncResult) GetWithTimeout(timeoutD, sleepD time.Duration) (reflect.Value, error) {
 	if asyncResult.backend == nil {
 		return reflect.Value{}, errors.New("Result backend not configured")

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/logger"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/RichardKnop/machinery/v1/utils"
 	"github.com/streadway/amqp"
@@ -62,7 +62,7 @@ func (amqpBroker *AMQPBroker) StartConsuming(consumerTag string, taskProcessor T
 
 	amqpBroker.stopChan = make(chan int)
 
-	if err := channel.Qos(
+	if err = channel.Qos(
 		3,     // prefetch count
 		0,     // prefetch size
 		false, // global
@@ -83,7 +83,7 @@ func (amqpBroker *AMQPBroker) StartConsuming(consumerTag string, taskProcessor T
 		return amqpBroker.retry, fmt.Errorf("Queue Consume: %s", err)
 	}
 
-	log.Print("[*] Waiting for messages. To exit press CTRL+C")
+	logger.Get().Print("[*] Waiting for messages. To exit press CTRL+C")
 
 	if err := amqpBroker.consume(deliveries, taskProcessor); err != nil {
 		return amqpBroker.retry, err // retry true
@@ -156,7 +156,7 @@ func (amqpBroker *AMQPBroker) consumeOne(d amqp.Delivery, taskProcessor TaskProc
 		return
 	}
 
-	log.Printf("Received new message: %s", d.Body)
+	logger.Get().Printf("Received new message: %s", d.Body)
 
 	signature := signatures.TaskSignature{}
 	if err := json.Unmarshal(d.Body, &signature); err != nil {
@@ -223,7 +223,7 @@ func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queu
 	}
 
 	// Declare an exchange
-	if err := channel.ExchangeDeclare(
+	if err = channel.ExchangeDeclare(
 		amqpBroker.config.Exchange,     // name of the exchange
 		amqpBroker.config.ExchangeType, // type
 		true,  // durable

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -3,11 +3,11 @@ package brokers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/logger"
 	"github.com/RichardKnop/machinery/v1/signatures"
 	"github.com/RichardKnop/machinery/v1/utils"
 	"github.com/garyburd/redigo/redis"
@@ -83,7 +83,7 @@ func (redisBroker *RedisBroker) StartConsuming(consumerTag string, taskProcessor
 	go func() {
 		defer redisBroker.wg.Done()
 
-		log.Print("[*] Waiting for messages. To exit press CTRL+C")
+		logger.Get().Print("[*] Waiting for messages. To exit press CTRL+C")
 
 		conn := redisBroker.pool.Get()
 
@@ -110,7 +110,7 @@ func (redisBroker *RedisBroker) StartConsuming(consumerTag string, taskProcessor
 				}
 
 				if len(items) != 2 {
-					log.Println("Got unexpected amount of byte arrays, ignoring")
+					logger.Get().Println("Got unexpected amount of byte arrays, ignoring")
 					continue
 				}
 				// items[0] - queue name (key), items[1] - value
@@ -208,7 +208,7 @@ func (redisBroker *RedisBroker) GetPendingTasks(queue string) ([]*signatures.Tas
 
 // Consume a single message
 func (redisBroker *RedisBroker) consumeOne(item []byte, taskProcessor TaskProcessor) {
-	log.Printf("Received new message: %s", item)
+	logger.Get().Printf("Received new message: %s", item)
 
 	signature := new(signatures.TaskSignature)
 	if err := json.Unmarshal(item, signature); err != nil {

--- a/v1/errors/errors.go
+++ b/v1/errors/errors.go
@@ -1,14 +1,14 @@
 package errors
 
 import (
-	"log"
+	"github.com/RichardKnop/machinery/v1/logger"
 )
 
 // Fail logs the error and exits the program
 // Only use this to handle critical errors
 func Fail(err error, msg string) {
 	if err != nil {
-		log.Panicf("%s: %s", msg, err)
+		logger.Get().Panicf("%s: %s", msg, err)
 	}
 }
 
@@ -16,6 +16,6 @@ func Fail(err error, msg string) {
 // Use this to log errors that should not exit the program
 func Log(err error, msg string) {
 	if err != nil {
-		log.Printf("[ERROR] %s: %s", msg, err)
+		logger.Get().Printf("[ERROR] %s: %s", msg, err)
 	}
 }

--- a/v1/logger/interface.go
+++ b/v1/logger/interface.go
@@ -1,0 +1,17 @@
+package logger
+
+// Interface defines an interface compatible with stdlib log module
+// as there's no standard interface, this is the closest we get, unfortunately.
+type Interface interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatalln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}

--- a/v1/logger/logger.go
+++ b/v1/logger/logger.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"log"
+	"os"
+)
+
+var logger Interface
+
+// Set sets a custom loger which satisfies the interface
+func Set(l Interface) {
+	logger = l
+}
+
+// Get returns the logger, should be used across the codebase to enable
+// developers to plug in their own loggers instead of the stdlib one
+func Get() Interface {
+	if logger == nil {
+		stdLogger := log.New(os.Stdout, "machinery: ", log.Lshortfile)
+		logger = Interface(stdLogger)
+	}
+	return logger
+}

--- a/v1/logger/logger_test.go
+++ b/v1/logger/logger_test.go
@@ -1,0 +1,11 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/RichardKnop/machinery/v1/logger"
+)
+
+func TestDefaultLogger(t *testing.T) {
+	logger.Get().Print("should not panic")
+}

--- a/v1/utils/retry.go
+++ b/v1/utils/retry.go
@@ -2,12 +2,13 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"time"
+
+	"github.com/RichardKnop/machinery/v1/logger"
 )
 
-// A useful closure we can use when there is a problem connecting to the broker
-// It uses Fibonacci sequence to space out retry attempts
+// RetryClosure - a useful closure we can use when there is a problem
+// connecting to the broker. It uses Fibonacci sequence to space out retry attempts
 var RetryClosure = func() func() {
 	retryIn := 0
 	fibonacci := Fibonacci()
@@ -16,7 +17,7 @@ var RetryClosure = func() func() {
 			durationString := fmt.Sprintf("%vs", retryIn)
 			duration, _ := time.ParseDuration(durationString)
 
-			log.Printf("Retrying in %v seconds", retryIn)
+			logger.Get().Printf("Retrying in %v seconds", retryIn)
 			time.Sleep(duration)
 		}
 		retryIn = fibonacci()


### PR DESCRIPTION
This PR adds a `github.com/RichardKnop/machinery/logger` package which is used instead of the default logger.

The following interface must be implemented:

```go
type Interface interface {
	Print(...interface{})
	Printf(string, ...interface{})
	Println(...interface{})

	Fatal(...interface{})
	Fatalf(string, ...interface{})
	Fatalln(...interface{})

	Panic(...interface{})
	Panicf(string, ...interface{})
	Panicln(...interface{})
}
```

You can set your custom logger using `Set` function exported by `github.com/RichardKnop/machinery/logger` package:

```go
logger.Set(myCustomLogger)
```

All uses of stdlib logger inside the library have been replaced by:

```go
logger.Get()
```