### PR TITLE
adding custom type support

### DIFF
--- a/examples/send/send.go
+++ b/examples/send/send.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/errors"
 	"github.com/RichardKnop/machinery/v1/signatures"
+	"github.com/RichardKnop/machinery/examples/tasks"
 )
 
 // Define flagss
@@ -110,6 +111,20 @@ func initTasks() {
 	task5 = signatures.TaskSignature{
 		Name: "panic_task",
 	}
+
+	line := exampletasks.Line{
+		Point1:exampletasks.Coordinates{0, -2},
+		Point2:exampletasks.Coordinates{3, 4}}
+
+	task6 = signatures.TaskSignature{
+		Name: "line_slope",
+		Args: []signatures.TaskArg{
+			{
+				Type:  "exampletasks.Line",
+				Value: line.InJson(),
+			},
+		},
+	}
 }
 
 func main() {
@@ -178,4 +193,11 @@ func main() {
 	initTasks()
 	asyncResult, err = server.SendTask(&task5)
 	errors.Fail(err, "Could not send task")
+
+	// Task which takes a custom struct type
+	initTasks()
+	asyncResult, err = server.SendTask(&task6)
+	result, err = asyncResult.Get()
+	errors.Fail(err, "Could not process custom tye task")
+	fmt.Printf("Line[(0,-2),(3,4)] Slope = %v\n", result.Interface())
 }

--- a/examples/tasks/tasks.go
+++ b/examples/tasks/tasks.go
@@ -2,6 +2,7 @@ package exampletasks
 
 import (
 	"errors"
+	"encoding/json"
 )
 
 // Add ...
@@ -25,4 +26,26 @@ func Multiply(args ...int64) (int64, error) {
 // PanicTask ...
 func PanicTask() (string, error) {
 	panic(errors.New("oops"))
+}
+
+//Custom type
+type Line struct {
+	Point1 Coordinates
+	Point2 Coordinates
+}
+
+func (l Line) InJson() string {
+	res, _ := json.Marshal(l)
+	return string(res)
+}
+
+type Coordinates struct {
+	X float64
+	Y float64
+}
+
+//Calculate slope of a line
+func LineSlope(line Line) (float64, error) {
+	slope := (line.Point2.Y - line.Point1.Y) / (line.Point2.X - line.Point1.X)
+	return slope, nil
 }

--- a/examples/worker/worker.go
+++ b/examples/worker/worker.go
@@ -7,6 +7,9 @@ import (
 	machinery "github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/errors"
+	"reflect"
+	"encoding/json"
+	"github.com/RichardKnop/machinery/v1/utils"
 )
 
 // Define flags
@@ -53,8 +56,19 @@ func init() {
 		"add":        exampletasks.Add,
 		"multiply":   exampletasks.Multiply,
 		"panic_task": exampletasks.PanicTask,
+		"line_slope": exampletasks.LineSlope,
 	}
 	server.RegisterTasks(tasks)
+
+	// Register custom struct type
+	utils.RegisterCustomType(exampletasks.Line{}, func(payload []byte) (res reflect.Value, err error) {
+		obj := &exampletasks.Line{}
+		if err = json.Unmarshal(payload, obj); err != nil {
+			return
+		}
+		res = reflect.ValueOf(*obj)
+		return
+	})
 
 	// The second argument is a consumer tag
 	// Ideally, each worker should have a unique tag (worker1, worker2 etc)

--- a/examples/worker/worker.go
+++ b/examples/worker/worker.go
@@ -61,9 +61,9 @@ func init() {
 	server.RegisterTasks(tasks)
 
 	// Register custom struct type
-	utils.RegisterCustomType(exampletasks.Line{}, func(payload []byte) (res reflect.Value, err error) {
+	utils.RegisterCustomType(exampletasks.Line{}, func(payload string) (res reflect.Value, err error) {
 		obj := &exampletasks.Line{}
-		if err = json.Unmarshal(payload, obj); err != nil {
+		if err = json.Unmarshal([]byte(payload), obj); err != nil {
 			return
 		}
 		res = reflect.ValueOf(*obj)

--- a/v1/utils/reflect.go
+++ b/v1/utils/reflect.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"encoding/base64"
 )
 
 var (
@@ -110,8 +109,7 @@ func ReflectValue(theType string, value interface{}) (reflect.Value, error) {
 			return reflectedValue, typeConversionError(value, theType)
 		}
 
-		buf, _ := base64.StdEncoding.DecodeString(stringValue)
-		result, err := customMarshalFunc(buf)
+		result, err := customMarshalFunc([]byte(stringValue))
 		if err != nil {
 			return reflectedValue, typeConversionError(value, theType)
 		}

--- a/v1/utils/reflect.go
+++ b/v1/utils/reflect.go
@@ -29,7 +29,7 @@ var (
 	}
 )
 
-type UnMarshalJson func([]byte) (reflect.Value, error)
+type UnMarshalJson func(string) (reflect.Value, error)
 
 var customMarshalFunctions = map[string]UnMarshalJson{}
 
@@ -109,7 +109,7 @@ func ReflectValue(theType string, value interface{}) (reflect.Value, error) {
 			return reflectedValue, typeConversionError(value, theType)
 		}
 
-		result, err := customMarshalFunc([]byte(stringValue))
+		result, err := customMarshalFunc(stringValue)
 		if err != nil {
 			return reflectedValue, typeConversionError(value, theType)
 		}


### PR DESCRIPTION
@RichardKnop Would you encourage a custom type registration like the one in this PR?

I don't like the fact that all the tasks must be falling under the registered supported types and it ends up with ugly functions in the code without structs. Hence, I am trying solve this by requiring to register custom types, if struct support is needed, and leaving the serialization for the client to implement. Let me know if you are willing to accept/reject this PR. I am also open to other ideas and hopefully I can contribute.

Please do let me know if there is any other better way to use structs if you think this isn't the right approach.

BTW, you have done a great job, putting this library. Kudos!!