### PR TITLE
Update `go get` url on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ So called tasks (or jobs if you like) are executed concurrently either by many w
 Add the Machinery library to your $GOPATH/src:
 
 ```
-go get github.com/RichardKnop/machinery
+go get github.com/RichardKnop/machinery/v1
 ```
 
 First, you will need to define some tasks. Look at sample tasks in `examples/tasks/tasks.go` to see a few examples.


### PR DESCRIPTION
The source code was moved to `v1` I guess. So no build able source files are now available in the root directory. I get this error: 

```
package github.com/RichardKnop/machinery: no buildable Go source files
```

However `go get github.com/RichardKnop/machinery/v1` should work just fine.