### PR TITLE
Fix error checking for Redis broker connections

### DIFF
--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -277,6 +277,9 @@ func (redisBroker *RedisBroker) newPool() *redis.Pool {
 			} else {
 				c, err = redis.Dial("tcp", redisBroker.host, opts...)
 			}
+			if err != nil {
+				return nil, err
+			}
 
 			if redisBroker.db != 0 {
 				_, err = c.Do("SELECT", redisBroker.db)


### PR DESCRIPTION
If the connection fails, return immediately. Otherwise the app will segfault a few lines later because `c` is nil.