### PR TITLE
Limit workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ type Config struct {
 	DefaultQueue          string                `yaml:"default_queue"`
 	QueueBindingArguments QueueBindingArguments `yaml:"queue_binding_arguments"`
 	BindingKey            string                `yaml:"binding_key"`
+	MaxWorkerInstances    int                   `yaml:"max_worker_instances"`
 	TLSConfig             *tls.Config
 }
 
@@ -236,12 +237,13 @@ import (
 )
 
 var cnf = config.Config{
-  Broker:        "amqp://guest:guest@localhost:5672/",
-  ResultBackend: "amqp://guest:guest@localhost:5672/",
-  Exchange:      "machinery_exchange",
-  ExchangeType:  "direct",
-  DefaultQueue:  "machinery_tasks",
-  BindingKey:    "machinery_task",
+  Broker:             "amqp://guest:guest@localhost:5672/",
+  ResultBackend:      "amqp://guest:guest@localhost:5672/",
+  Exchange:           "machinery_exchange",
+  ExchangeType:       "direct",
+  DefaultQueue:       "machinery_tasks",
+  BindingKey:         "machinery_task",
+  MaxWorkerInstances: 0,
 }
 
 server, err := machinery.NewServer(&cnf)
@@ -262,7 +264,10 @@ if err != nil {
 }
 ```
 
-Each worker will only consume registered tasks.
+Each worker will only consume registered tasks. For each task on the queue the Worker.Process() method will will be run
+in a goroutine. Use the `MaxWorkerInstances` config option to limit the number of concurrently running Worker.Process()
+calls (per worker). `MaxWorkerInstances = 1` will serialize task execution. `MaxWorkerInstances = 0` makes the number of
+concurrently executed tasks unlimited (default).
 
 ## Tasks
 

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	DefaultQueue          string                `yaml:"default_queue"`
 	QueueBindingArguments QueueBindingArguments `yaml:"queue_binding_arguments"`
 	BindingKey            string                `yaml:"binding_key"`
+	MaxWorkerInstances    int                   `yaml:"max_worker_instances"`
 	TLSConfig             *tls.Config
 }
 

--- a/v1/config/config_test.go
+++ b/v1/config/config_test.go
@@ -20,6 +20,7 @@ queue_binding_arguments:
   image-type: png
   x-match: any
 binding_key: machinery_task
+max_worker_instances: 10
 `
 
 func TestReadFromFile(t *testing.T) {
@@ -51,4 +52,6 @@ func TestParseYAMLConfig(t *testing.T) {
 	assert.Equal(t, "machinery_task", cfg.BindingKey)
 	assert.Equal(t, "any", cfg.QueueBindingArguments["x-match"])
 	assert.Equal(t, "png", cfg.QueueBindingArguments["image-type"])
+	assert.Equal(t, 10, cfg.MaxWorkerInstances)
+
 }

--- a/v1/config/testconfig.yml
+++ b/v1/config/testconfig.yml
@@ -9,3 +9,4 @@ queue_binding_arguments:
   image-type: png
   x-match: any
 binding_key: machinery_task
+max_worker_instances: 10


### PR DESCRIPTION
This PR is adding a config option `MaxWorkerInstances` to limit the number of concurrently executed tasks per worker. `MaxWorkerInstances=0` (default) allows an unlimited number of concurrent task executions, so the default behavior of machinery stays the same. `MaxWorkerInstances=1` essentially serializes task execution (which is a feature that I need).
Limiting is implemented for the Redis and the AMQP brokers.

All tests are passing with these changes. I would be glad if this could be merged. Let me know if there is anything else I can do to make that happen.