### PR TITLE
fixed worker example server redeclaration

### DIFF
--- a/examples/worker/worker.go
+++ b/examples/worker/worker.go
@@ -48,7 +48,8 @@ func init() {
 		errors.Fail(err, "Could not parse config file")
 	}
 
-	server, err := machinery.NewServer(&cnf)
+	var err error
+	server, err = machinery.NewServer(&cnf)
 	errors.Fail(err, "Could not initialize server")
 
 	// Register tasks

--- a/examples/worker/worker.go
+++ b/examples/worker/worker.go
@@ -48,7 +48,6 @@ func init() {
 		errors.Fail(err, "Could not parse config file")
 	}
 
-	var err error
 	server, err = machinery.NewServer(&cnf)
 	errors.Fail(err, "Could not initialize server")
 


### PR DESCRIPTION
server is redeclared in the `init` function context