### PR TITLE
Allow tasks to have a context

### DIFF
--- a/v1/task_test.go
+++ b/v1/task_test.go
@@ -1,6 +1,7 @@
 package machinery_test
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -34,6 +35,19 @@ func TestInterfaceValuedResult(t *testing.T) {
 	task, err := machinery.NewTask(f, []signatures.TaskArg{})
 	assert.NoError(t, err)
 
+	taskResults, err := task.Call()
+	assert.NoError(t, err)
+	assert.Equal(t, "float64", taskResults[0].Type)
+	assert.Equal(t, math.Pi, taskResults[0].Value)
+}
+
+func TestTaskHasContext(t *testing.T) {
+	f := func(c context.Context) (interface{}, error) {
+		assert.NotNil(t, c)
+		return math.Pi, nil
+	}
+	task, err := machinery.NewTask(f, []signatures.TaskArg{})
+	assert.NoError(t, err)
 	taskResults, err := task.Call()
 	assert.NoError(t, err)
 	assert.Equal(t, "float64", taskResults[0].Type)

--- a/v1/utils/reflect.go
+++ b/v1/utils/reflect.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -23,6 +24,8 @@ var (
 		"float64": reflect.TypeOf(float64(0.5)),
 		"string":  reflect.TypeOf(string("")),
 	}
+
+	ctxType = reflect.TypeOf((*context.Context)(nil)).Elem()
 
 	typeConversionError = func(argValue interface{}, argTypeStr string) error {
 		return fmt.Errorf("%v is not %v", argValue, argTypeStr)
@@ -144,4 +147,9 @@ func getFloatValue(theType string, value interface{}) (float64, error) {
 
 	// Now we can return float64
 	return number, nil
+}
+
+// IsContextType checks to see if the type is a context.Context
+func IsContextType(t reflect.Type) bool {
+	return t == ctxType
 }


### PR DESCRIPTION
This is just a preview for feedback,

Want to be able to add contexts to tasks to allow for open-tracing to be applied to contexts.

The first bit of work is to enable tasks to have contexts. To not break compatibility I have made providing a context optional.

If a task signature contains a context as its first parameter we inject a context into the task. In future work will add a context factory so people can generate there own contexts. (We could also use this to make tasks have a limited run time)

