### PR TITLE
Added support for delayed tasks with redis broker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,6 @@ if err != nil {
 }
 ```
 
-Delayed tasks currently only work with `AMQP` backend.
-
 ### Get Pending Tasks
 
 Tasks currently waiting in the queue to be consumed by workers can be inspected, e.g.:


### PR DESCRIPTION
Redis broker now supports delayed tasks as well.

Delayed tasks are stored in a sorted set via `ZADD` command and a separate goroutines watches the `delayed_tasks` key in the sorted set via `ZRANGEBYSCORE`.