### PR TITLE
Retry Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Simply put, when a worker receives a message like this:
   ],
   "Immutable": false,
   "RetryCount": 0,
+  "RetryTimeout": 0,
   "OnSuccess": null,
   "OnError": null,
   "ChordCallback": null
@@ -390,6 +391,7 @@ type Signature struct {
   Headers        Headers
   Immutable      bool
   RetryCount     int
+  RetryTimeout   int
   OnSuccess      []*Signature
   OnError        []*Signature
   ChordCallback  *Signature
@@ -413,6 +415,8 @@ type Signature struct {
 `Immutable` is a flag which defines whether a result of the executed task can be modified or not. This is important with `OnSuccess` callbacks. Immutable task will not pass its result to its success callbacks while a mutable task will prepend its result to args sent to callback tasks. Long story short, set Immutable to false if you want to pass result of the first task in a chain to the second task.
 
 `RetryCount` specifies how many times a failed task should be retried (defaults to 0). Retry attempts will be spaced out in time, after each failure another attempt will be scheduled further to the future.
+
+`RetryTimeout` specifies how long to wait before resending task to the queue for retry attempt. Default behaviour is to use fibonacci sequence to increase the timeout after each failed retry attempt.
 
 `OnSuccess` defines tasks which will be called after the task has executed successfully. It is a slice of task signature structs.
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Simply put, when a worker receives a message like this:
     }
   ],
   "Immutable": false,
+  "RetryCount": 0,
   "OnSuccess": null,
   "OnError": null,
   "ChordCallback": null
@@ -388,6 +389,7 @@ type Signature struct {
   Args           []Arg
   Headers        Headers
   Immutable      bool
+  RetryCount     int
   OnSuccess      []*Signature
   OnError        []*Signature
   ChordCallback  *Signature
@@ -409,6 +411,8 @@ type Signature struct {
 `Headers` is a list of headers that will be used when publishing the task to AMQP queue.
 
 `Immutable` is a flag which defines whether a result of the executed task can be modified or not. This is important with `OnSuccess` callbacks. Immutable task will not pass its result to its success callbacks while a mutable task will prepend its result to args sent to callback tasks. Long story short, set Immutable to false if you want to pass result of the first task in a chain to the second task.
+
+`RetryCount` specifies how many times a failed task should be retried (defaults to 0). Retry attempts will be spaced out in time, after each failure another attempt will be scheduled further to the future.
 
 `OnSuccess` defines tasks which will be called after the task has executed successfully. It is a slice of task signature structs.
 

--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -174,6 +174,12 @@ func (b *AMQPBackend) SetStateFailure(signature *tasks.Signature, err string) er
 	return b.markTaskCompleted(signature, taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *AMQPBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // GetState returns the latest task state. It will only return the status once
 // as the message will get consumed and removed from the queue.
 func (b *AMQPBackend) GetState(taskUUID string) (*tasks.TaskState, error) {

--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -68,7 +68,7 @@ func (b *AMQPBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*
 
 	queueState, err := channel.QueueInspect(groupUUID)
 	if err != nil {
-		return nil, fmt.Errorf("Queue Inspect: %v", err)
+		return nil, fmt.Errorf("Queue inspect error: %v", err)
 	}
 
 	if queueState.Messages != groupTaskCount {
@@ -85,7 +85,7 @@ func (b *AMQPBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*
 		nil,        // arguments
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Queue Consume: %s", err)
+		return nil, fmt.Errorf("Queue consume error: %s", err)
 	}
 
 	states := make([]*tasks.TaskState, groupTaskCount)
@@ -144,6 +144,12 @@ func (b *AMQPBackend) SetStateStarted(signature *tasks.Signature) error {
 	return b.updateState(taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *AMQPBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // SetStateSuccess updates task state to SUCCESS
 func (b *AMQPBackend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	taskState := tasks.NewSuccessTaskState(signature, results)
@@ -172,12 +178,6 @@ func (b *AMQPBackend) SetStateFailure(signature *tasks.Signature, err string) er
 	}
 
 	return b.markTaskCompleted(signature, taskState)
-}
-
-// SetStateRetry updates task state to RETRY
-func (b *AMQPBackend) SetStateRetry(signature *tasks.Signature) error {
-	state := tasks.NewRetryTaskState(signature)
-	return b.updateState(state)
 }
 
 // GetState returns the latest task state. It will only return the status once
@@ -227,7 +227,7 @@ func (b *AMQPBackend) PurgeGroupMeta(groupUUID string) error {
 func (b *AMQPBackend) updateState(taskState *tasks.TaskState) error {
 	message, err := json.Marshal(taskState)
 	if err != nil {
-		return fmt.Errorf("JSON Encode Message: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	conn, channel, _, confirmsChan, err := b.connect(taskState.TaskUUID)
@@ -298,7 +298,7 @@ func (b *AMQPBackend) markTaskCompleted(signature *tasks.Signature, taskState *t
 
 	message, err := json.Marshal(taskState)
 	if err != nil {
-		return fmt.Errorf("JSON Encode Message: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	conn, channel, _, confirmsChan, err := b.connect(signature.GroupUUID)
@@ -357,7 +357,7 @@ func (b *AMQPBackend) connect(queueName string) (*amqp.Connection, *amqp.Channel
 		nil,   // arguments
 	)
 	if err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Exchange Declare: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Exchange declare error: %s", err)
 	}
 
 	// Declare a queue
@@ -373,7 +373,7 @@ func (b *AMQPBackend) connect(queueName string) (*amqp.Connection, *amqp.Channel
 		arguments,
 	)
 	if err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Queue Declare: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Queue declare error: %s", err)
 	}
 
 	// Bind the queue
@@ -384,7 +384,7 @@ func (b *AMQPBackend) connect(queueName string) (*amqp.Connection, *amqp.Channel
 		false,               // noWait
 		nil,                 // arguments
 	); err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Queue Bind: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Queue bind error: %s", err)
 	}
 
 	// Enable publish confirmations
@@ -408,13 +408,13 @@ func (b *AMQPBackend) open() (*amqp.Connection, *amqp.Channel, error) {
 	// and will dial a plain connection when it encounters an amqp:// scheme.
 	conn, err = amqp.DialTLS(b.cnf.Broker, b.cnf.TLSConfig)
 	if err != nil {
-		return conn, channel, fmt.Errorf("Dial: %s", err)
+		return conn, channel, fmt.Errorf("Dial error: %s", err)
 	}
 
 	// Open a channel
 	channel, err = conn.Channel()
 	if err != nil {
-		return conn, channel, fmt.Errorf("Channel: %s", err)
+		return conn, channel, fmt.Errorf("Open channel error: %s", err)
 	}
 
 	return conn, channel, nil
@@ -429,7 +429,7 @@ func (b *AMQPBackend) inspectQueue(channel *amqp.Channel, queueName string) (*am
 
 	queueState, err = channel.QueueInspect(queueName)
 	if err != nil {
-		return nil, fmt.Errorf("Queue Inspect: %v", err)
+		return nil, fmt.Errorf("Queue inspect error: %v", err)
 	}
 
 	return &queueState, nil
@@ -439,13 +439,13 @@ func (b *AMQPBackend) inspectQueue(channel *amqp.Channel, queueName string) (*am
 func (b *AMQPBackend) close(channel *amqp.Channel, conn *amqp.Connection) error {
 	if channel != nil {
 		if err := channel.Close(); err != nil {
-			return fmt.Errorf("Channel Close: %s", err)
+			return fmt.Errorf("Close channel error: %s", err)
 		}
 	}
 
 	if conn != nil {
 		if err := conn.Close(); err != nil {
-			return fmt.Errorf("Connection Close: %s", err)
+			return fmt.Errorf("Close connection error: %s", err)
 		}
 	}
 

--- a/v1/backends/eager.go
+++ b/v1/backends/eager.go
@@ -101,6 +101,12 @@ func (b *EagerBackend) SetStateStarted(signature *tasks.Signature) error {
 	return b.updateState(state)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *EagerBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // SetStateSuccess updates task state to SUCCESS
 func (b *EagerBackend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	state := tasks.NewSuccessTaskState(signature, results)
@@ -110,12 +116,6 @@ func (b *EagerBackend) SetStateSuccess(signature *tasks.Signature, results []*ta
 // SetStateFailure updates task state to FAILURE
 func (b *EagerBackend) SetStateFailure(signature *tasks.Signature, err string) error {
 	state := tasks.NewFailureTaskState(signature, err)
-	return b.updateState(state)
-}
-
-// SetStateRetry updates task state to RETRY
-func (b *EagerBackend) SetStateRetry(signature *tasks.Signature) error {
-	state := tasks.NewRetryTaskState(signature)
 	return b.updateState(state)
 }
 

--- a/v1/backends/eager.go
+++ b/v1/backends/eager.go
@@ -113,6 +113,12 @@ func (b *EagerBackend) SetStateFailure(signature *tasks.Signature, err string) e
 	return b.updateState(state)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *EagerBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // GetState returns the latest task state
 func (b *EagerBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	tasktStateBytes, ok := b.tasks[taskUUID]

--- a/v1/backends/eager_test.go
+++ b/v1/backends/eager_test.go
@@ -258,6 +258,19 @@ func (s *EagerBackendTestSuite) TestSetStateFailure() {
 	}
 }
 
+func (s *EagerBackendTestSuite) TestSetStateRetry() {
+	// task6
+	{
+		t := s.st[5]
+		s.backend.SetStateRetry(t)
+		st, err := s.backend.GetState(t.UUID)
+		s.Nil(err)
+		if st != nil {
+			s.Equal(tasks.RetryState, st.State)
+		}
+	}
+}
+
 func (s *EagerBackendTestSuite) TestGetState() {
 	// get something not existed -- empty string
 	st, err := s.backend.GetState("")

--- a/v1/backends/interface.go
+++ b/v1/backends/interface.go
@@ -15,9 +15,9 @@ type Interface interface {
 	SetStatePending(signature *tasks.Signature) error
 	SetStateReceived(signature *tasks.Signature) error
 	SetStateStarted(signature *tasks.Signature) error
+	SetStateRetry(signature *tasks.Signature) error
 	SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error
 	SetStateFailure(signature *tasks.Signature, err string) error
-	SetStateRetry(signature *tasks.Signature) error
 	GetState(taskUUID string) (*tasks.TaskState, error)
 	// Purging stored stored tasks states and group meta data
 	PurgeState(taskUUID string) error

--- a/v1/backends/interface.go
+++ b/v1/backends/interface.go
@@ -17,6 +17,7 @@ type Interface interface {
 	SetStateStarted(signature *tasks.Signature) error
 	SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error
 	SetStateFailure(signature *tasks.Signature, err string) error
+	SetStateRetry(signature *tasks.Signature) error
 	GetState(taskUUID string) (*tasks.TaskState, error)
 	// Purging stored stored tasks states and group meta data
 	PurgeState(taskUUID string) error

--- a/v1/backends/memcache.go
+++ b/v1/backends/memcache.go
@@ -139,6 +139,12 @@ func (b *MemcacheBackend) SetStateStarted(signature *tasks.Signature) error {
 	return b.updateState(taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *MemcacheBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // SetStateSuccess updates task state to SUCCESS
 func (b *MemcacheBackend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	taskState := tasks.NewSuccessTaskState(signature, results)
@@ -149,12 +155,6 @@ func (b *MemcacheBackend) SetStateSuccess(signature *tasks.Signature, results []
 func (b *MemcacheBackend) SetStateFailure(signature *tasks.Signature, err string) error {
 	taskState := tasks.NewFailureTaskState(signature, err)
 	return b.updateState(taskState)
-}
-
-// SetStateRetry updates task state to RETRY
-func (b *MemcacheBackend) SetStateRetry(signature *tasks.Signature) error {
-	state := tasks.NewRetryTaskState(signature)
-	return b.updateState(state)
 }
 
 // GetState returns the latest task state

--- a/v1/backends/memcache.go
+++ b/v1/backends/memcache.go
@@ -151,6 +151,12 @@ func (b *MemcacheBackend) SetStateFailure(signature *tasks.Signature, err string
 	return b.updateState(taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *MemcacheBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // GetState returns the latest task state
 func (b *MemcacheBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	item, err := b.getClient().Get(taskUUID)

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -130,6 +130,12 @@ func (b *MongodbBackend) SetStateStarted(signature *tasks.Signature) error {
 	return b.updateState(signature, update)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *MongodbBackend) SetStateRetry(signature *tasks.Signature) error {
+	update := bson.M{"state": tasks.RetryState}
+	return b.updateState(signature, update)
+}
+
 // SetStateSuccess updates task state to SUCCESS
 func (b *MongodbBackend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	bsonResults := make([]bson.M, len(results))
@@ -149,12 +155,6 @@ func (b *MongodbBackend) SetStateSuccess(signature *tasks.Signature, results []*
 // SetStateFailure updates task state to FAILURE
 func (b *MongodbBackend) SetStateFailure(signature *tasks.Signature, err string) error {
 	update := bson.M{"state": tasks.FailureState, "error": err}
-	return b.updateState(signature, update)
-}
-
-// SetStateRetry updates task state to RETRY
-func (b *MongodbBackend) SetStateRetry(signature *tasks.Signature) error {
-	update := bson.M{"state": tasks.RetryState}
 	return b.updateState(signature, update)
 }
 

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -152,6 +152,12 @@ func (b *MongodbBackend) SetStateFailure(signature *tasks.Signature, err string)
 	return b.updateState(signature, update)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *MongodbBackend) SetStateRetry(signature *tasks.Signature) error {
+	update := bson.M{"state": tasks.RetryState}
+	return b.updateState(signature, update)
+}
+
 // GetState returns the latest task state
 func (b *MongodbBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	if err := b.connect(); err != nil {

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -149,6 +149,12 @@ func (b *RedisBackend) SetStateStarted(signature *tasks.Signature) error {
 	return b.updateState(taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *RedisBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // SetStateSuccess updates task state to SUCCESS
 func (b *RedisBackend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	taskState := tasks.NewSuccessTaskState(signature, results)
@@ -159,12 +165,6 @@ func (b *RedisBackend) SetStateSuccess(signature *tasks.Signature, results []*ta
 func (b *RedisBackend) SetStateFailure(signature *tasks.Signature, err string) error {
 	taskState := tasks.NewFailureTaskState(signature, err)
 	return b.updateState(taskState)
-}
-
-// SetStateRetry updates task state to RETRY
-func (b *RedisBackend) SetStateRetry(signature *tasks.Signature) error {
-	state := tasks.NewRetryTaskState(signature)
-	return b.updateState(state)
 }
 
 // GetState returns the latest task state

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -161,6 +161,12 @@ func (b *RedisBackend) SetStateFailure(signature *tasks.Signature, err string) e
 	return b.updateState(taskState)
 }
 
+// SetStateRetry updates task state to RETRY
+func (b *RedisBackend) SetStateRetry(signature *tasks.Signature) error {
+	state := tasks.NewRetryTaskState(signature)
+	return b.updateState(state)
+}
+
 // GetState returns the latest task state
 func (b *RedisBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	conn := b.open()

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -42,7 +42,7 @@ func (b *AMQPBroker) StartConsuming(consumerTag string, taskProcessor TaskProces
 		0,     // prefetch size
 		false, // global
 	); err != nil {
-		return b.retry, fmt.Errorf("Channel Qos: %s", err)
+		return b.retry, fmt.Errorf("Channel qos error: %s", err)
 	}
 
 	deliveries, err := channel.Consume(
@@ -55,7 +55,7 @@ func (b *AMQPBroker) StartConsuming(consumerTag string, taskProcessor TaskProces
 		nil,         // arguments
 	)
 	if err != nil {
-		return b.retry, fmt.Errorf("Queue Consume: %s", err)
+		return b.retry, fmt.Errorf("Queue consume error: %s", err)
 	}
 
 	log.INFO.Print("[*] Waiting for messages. To exit press CTRL+C")
@@ -90,7 +90,7 @@ func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 
 	message, err := json.Marshal(signature)
 	if err != nil {
-		return fmt.Errorf("JSON Encode Message: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	conn, channel, _, confirmsChan, err := b.connect()
@@ -219,7 +219,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 
 	message, err := json.Marshal(signature)
 	if err != nil {
-		return fmt.Errorf("JSON Encode Message: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	// Connect to server
@@ -239,7 +239,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 		false, // noWait
 		nil,   // arguments
 	); err != nil {
-		return fmt.Errorf("Exchange Declare: %s", err)
+		return fmt.Errorf("Exchange declare error: %s", err)
 	}
 
 	// It's necessary to redeclare the queue each time (to zero its TTL timer).
@@ -269,7 +269,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 		holdQueueArgs, // arguments
 	)
 	if err != nil {
-		return fmt.Errorf("Queue Declare: %s", err)
+		return fmt.Errorf("Queue declare error: %s", err)
 	}
 
 	// Bind the queue
@@ -280,7 +280,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 		false,               // noWait
 		amqp.Table(b.cnf.AMQP.QueueBindingArguments), // arguments
 	); err != nil {
-		return fmt.Errorf("Queue Bind: %s", err)
+		return fmt.Errorf("Queue bind error: %s", err)
 	}
 
 	if err := channel.Publish(
@@ -327,7 +327,7 @@ func (b *AMQPBroker) connect() (*amqp.Connection, *amqp.Channel, amqp.Queue, <-c
 		false, // noWait
 		nil,   // arguments
 	); err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Exchange Declare: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Exchange declare error: %s", err)
 	}
 
 	// Declare a queue
@@ -340,7 +340,7 @@ func (b *AMQPBroker) connect() (*amqp.Connection, *amqp.Channel, amqp.Queue, <-c
 		nil,                // arguments
 	)
 	if err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Queue Declare: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Queue declare error: %s", err)
 	}
 
 	// Bind the queue
@@ -351,7 +351,7 @@ func (b *AMQPBroker) connect() (*amqp.Connection, *amqp.Channel, amqp.Queue, <-c
 		false,                 // noWait
 		amqp.Table(b.cnf.AMQP.QueueBindingArguments), // arguments
 	); err != nil {
-		return conn, channel, queue, nil, fmt.Errorf("Queue Bind: %s", err)
+		return conn, channel, queue, nil, fmt.Errorf("Queue bind error: %s", err)
 	}
 
 	// Enable publish confirmations
@@ -375,13 +375,13 @@ func (b *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, error) {
 	// and will dial a plain connection when it encounters an amqp:// scheme.
 	conn, err = amqp.DialTLS(b.cnf.Broker, b.cnf.TLSConfig)
 	if err != nil {
-		return conn, channel, fmt.Errorf("Dial: %s", err)
+		return conn, channel, fmt.Errorf("Dial error: %s", err)
 	}
 
 	// Open a channel
 	channel, err = conn.Channel()
 	if err != nil {
-		return conn, channel, fmt.Errorf("Channel: %s", err)
+		return conn, channel, fmt.Errorf("Open channel error: %s", err)
 	}
 
 	return conn, channel, nil
@@ -391,13 +391,13 @@ func (b *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, error) {
 func (b *AMQPBroker) close(channel *amqp.Channel, conn *amqp.Connection) error {
 	if channel != nil {
 		if err := channel.Close(); err != nil {
-			return fmt.Errorf("Channel Close: %s", err)
+			return fmt.Errorf("Close channel error: %s", err)
 		}
 	}
 
 	if conn != nil {
 		if err := conn.Close(); err != nil {
-			return fmt.Errorf("Connection Close: %s", err)
+			return fmt.Errorf("Close connection error: %s", err)
 		}
 	}
 

--- a/v1/brokers/eager.go
+++ b/v1/brokers/eager.go
@@ -44,13 +44,13 @@ func (eagerBroker *EagerBroker) Publish(task *tasks.Signature) error {
 	// and unmarshal it back
 	message, err := json.Marshal(task)
 	if err != nil {
-		return fmt.Errorf("json marshaling failed: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	signature := new(tasks.Signature)
 	err = json.Unmarshal(message, &signature)
 	if err != nil {
-		return fmt.Errorf("json unmarshaling failed: %v", err)
+		return fmt.Errorf("JSON unmarshal error: %v", err)
 	}
 
 	// blocking call to the task directly

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -135,12 +135,12 @@ func (b *RedisBroker) StopConsuming() {
 func (b *RedisBroker) Publish(signature *tasks.Signature) error {
 	msg, err := json.Marshal(signature)
 	if err != nil {
-		return fmt.Errorf("JSON Encode Message: %v", err)
+		return fmt.Errorf("JSON marshal error: %v", err)
 	}
 
 	conn, err := b.open()
 	if err != nil {
-		return fmt.Errorf("Dial: %s", err)
+		return fmt.Errorf("Dial error: %s", err)
 	}
 	defer conn.Close()
 
@@ -166,7 +166,7 @@ func (b *RedisBroker) Publish(signature *tasks.Signature) error {
 func (b *RedisBroker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	conn, err := b.open()
 	if err != nil {
-		return nil, fmt.Errorf("Dial: %s", err)
+		return nil, fmt.Errorf("Dial error: %s", err)
 	}
 	defer conn.Close()
 

--- a/v1/retry/fibonacci.go
+++ b/v1/retry/fibonacci.go
@@ -8,3 +8,13 @@ func Fibonacci() func() int {
 		return a
 	}
 }
+
+// FibonacciNext returns next number in Fibonacci sequence greater than start
+func FibonacciNext(start int) int {
+	fib := Fibonacci()
+	num := fib()
+	for num <= start {
+		num = fib()
+	}
+	return num
+}

--- a/v1/retry/fibonacci_test.go
+++ b/v1/retry/fibonacci_test.go
@@ -1,10 +1,10 @@
 package retry_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/RichardKnop/machinery/v1/retry"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFibonacci(t *testing.T) {
@@ -19,7 +19,14 @@ func TestFibonacci(t *testing.T) {
 		fibonacci(),
 	}
 
-	if !reflect.DeepEqual(sequence, []int{1, 1, 2, 3, 5, 8}) {
-		t.Errorf("sequence = %v, want [1, 1, 2, 3, 5, 8]", sequence)
-	}
+	assert.EqualValues(t, sequence, []int{1, 1, 2, 3, 5, 8})
+}
+
+func TestFibonacciNext(t *testing.T) {
+	assert.Equal(t, 1, retry.FibonacciNext(0))
+	assert.Equal(t, 2, retry.FibonacciNext(1))
+	assert.Equal(t, 5, retry.FibonacciNext(3))
+	assert.Equal(t, 5, retry.FibonacciNext(4))
+	assert.Equal(t, 8, retry.FibonacciNext(5))
+	assert.Equal(t, 13, retry.FibonacciNext(8))
 }

--- a/v1/server.go
+++ b/v1/server.go
@@ -119,7 +119,7 @@ func (server *Server) IsTaskRegistered(name string) bool {
 func (server *Server) GetRegisteredTask(name string) (interface{}, error) {
 	taskFunc, ok := server.registeredTasks[name]
 	if !ok {
-		return nil, fmt.Errorf("Task not registered: %s", name)
+		return nil, fmt.Errorf("Task not registered error: %s", name)
 	}
 	return taskFunc, nil
 }
@@ -138,11 +138,11 @@ func (server *Server) SendTask(signature *tasks.Signature) (*backends.AsyncResul
 
 	// Set initial task state to PENDING
 	if err := server.backend.SetStatePending(signature); err != nil {
-		return nil, fmt.Errorf("Set State Pending: %v", err)
+		return nil, fmt.Errorf("Set state pending error: %v", err)
 	}
 
 	if err := server.broker.Publish(signature); err != nil {
-		return nil, fmt.Errorf("Publish Message: %v", err)
+		return nil, fmt.Errorf("Publish message error: %v", err)
 	}
 
 	return backends.NewAsyncResult(signature, server.backend), nil
@@ -186,7 +186,7 @@ func (server *Server) SendGroup(group *tasks.Group) ([]*backends.AsyncResult, er
 
 			// Publish task
 			if err := server.broker.Publish(s); err != nil {
-				errorsChan <- fmt.Errorf("Publish Message: %v", err)
+				errorsChan <- fmt.Errorf("Publish message error: %v", err)
 				return
 			}
 

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -28,6 +28,7 @@ type Signature struct {
 	Headers        Headers
 	Immutable      bool
 	RetryCount     int
+	RetryTimeout   int
 	OnSuccess      []*Signature
 	OnError        []*Signature
 	ChordCallback  *Signature

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -27,6 +27,7 @@ type Signature struct {
 	Args           []Arg
 	Headers        Headers
 	Immutable      bool
+	RetryCount     int
 	OnSuccess      []*Signature
 	OnError        []*Signature
 	ChordCallback  *Signature

--- a/v1/tasks/state.go
+++ b/v1/tasks/state.go
@@ -11,6 +11,8 @@ const (
 	SuccessState = "SUCCESS"
 	// FailureState - when processing of the task fails
 	FailureState = "FAILURE"
+	// RetryState - when failed task has been scheduled for retry
+	RetryState = "RETRY"
 )
 
 // TaskState represents a state of a task
@@ -70,6 +72,14 @@ func NewFailureTaskState(signature *Signature, err string) *TaskState {
 		TaskUUID: signature.UUID,
 		State:    FailureState,
 		Error:    err,
+	}
+}
+
+// NewRetryTaskState ...
+func NewRetryTaskState(signature *Signature) *TaskState {
+	return &TaskState{
+		TaskUUID: signature.UUID,
+		State:    RetryState,
 	}
 }
 

--- a/v1/tasks/task.go
+++ b/v1/tasks/task.go
@@ -38,7 +38,7 @@ func New(taskFunc interface{}, args []Arg) (*Task, error) {
 	}
 
 	if err := task.ReflectArgs(args); err != nil {
-		return nil, fmt.Errorf("Reflect task args: %v", err)
+		return nil, fmt.Errorf("Reflect task args error: %v", err)
 	}
 
 	return task, nil

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -3,6 +3,7 @@ package machinery
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"os"
 	"os/signal"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/RichardKnop/machinery/v1/backends"
 	"github.com/RichardKnop/machinery/v1/log"
+	"github.com/RichardKnop/machinery/v1/retry"
 	"github.com/RichardKnop/machinery/v1/tasks"
 )
 
@@ -82,48 +84,76 @@ func (worker *Worker) Process(signature *tasks.Signature) error {
 		return nil
 	}
 
-	backend := worker.server.GetBackend()
-
 	// Update task state to RECEIVED
-	if err = backend.SetStateReceived(signature); err != nil {
-		return fmt.Errorf("Set State Received: %v", err)
+	if err = worker.server.GetBackend().SetStateReceived(signature); err != nil {
+		return fmt.Errorf("Set state received error: %v", err)
 	}
 
 	// Prepare task for processing
 	task, err := tasks.New(taskFunc, signature.Args)
+	// if this failed, it means the task is malformed, probably has invalid
+	// signature, go directly to task failed without checking whether to retry
 	if err != nil {
-		worker.finalizeError(signature, err)
+		worker.taskFailed(signature, err)
 		return err
 	}
 
 	// Update task state to STARTED
-	if err = backend.SetStateStarted(signature); err != nil {
-		return fmt.Errorf("Set State Started: %v", err)
+	if err = worker.server.GetBackend().SetStateStarted(signature); err != nil {
+		return fmt.Errorf("Set state started error: %v", err)
 	}
 
 	// Call the task
 	results, err := task.Call()
 	if err != nil {
-		return worker.finalizeError(signature, err)
+		// Let's retry the task
+		if signature.RetryCount > 0 {
+			return worker.taskRetry(signature)
+		}
+
+		return worker.taskFailed(signature, err)
 	}
 
-	return worker.finalizeSuccess(signature, results)
+	return worker.taskSucceeded(signature, results)
 }
 
-// Task succeeded, update state and trigger success callbacks
-func (worker *Worker) finalizeSuccess(signature *tasks.Signature, taskResults []*tasks.TaskResult) error {
-	// Update task state to SUCCESS
-	backend := worker.server.GetBackend()
+// retryTask decrements RetryCount counter and republishes the task to the queue
+func (worker *Worker) taskRetry(signature *tasks.Signature) error {
+	// Update task state to RETRY
+	if err := worker.server.GetBackend().SetStateRetry(signature); err != nil {
+		return fmt.Errorf("Set state retry error: %v", err)
+	}
 
-	if err := backend.SetStateSuccess(signature, taskResults); err != nil {
-		return fmt.Errorf("Set State Success: %v", err)
+	// Decrement the retry counter, when it reaches 0, we won't retry again
+	signature.RetryCount--
+
+	// Increase retry timeout
+	signature.RetryTimeout = retry.FibonacciNext(signature.RetryTimeout)
+
+	// Delay task by signature.RetryTimeout seconds
+	eta := time.Now().UTC().Add(time.Second * time.Duration(signature.RetryTimeout))
+	signature.ETA = &eta
+
+	log.WARNING.Printf("Task %s failed. Going to retry in %ds.", signature.UUID, signature.RetryTimeout)
+
+	// Send the task back to the queue
+	_, err := worker.server.SendTask(signature)
+	return err
+}
+
+// taskSucceeded updates the task state and triggers success callbacks or a
+// chord callback if this was the last task of a group with a chord callback
+func (worker *Worker) taskSucceeded(signature *tasks.Signature, taskResults []*tasks.TaskResult) error {
+	// Update task state to SUCCESS
+	if err := worker.server.GetBackend().SetStateSuccess(signature, taskResults); err != nil {
+		return fmt.Errorf("Set state success error: %v", err)
 	}
 
 	debugResults := make([]string, len(taskResults))
 	for i, taskResult := range taskResults {
 		debugResults[i] = fmt.Sprintf("%v", taskResult.Value)
 	}
-	log.INFO.Printf("Processed %s. Results = [%v]", signature.UUID, strings.Join(debugResults, ", "))
+	log.INFO.Printf("Processed task %s. Results = [%v]", signature.UUID, strings.Join(debugResults, ", "))
 
 	// Trigger success callbacks
 	for _, successTask := range signature.OnSuccess {
@@ -153,7 +183,7 @@ func (worker *Worker) finalizeSuccess(signature *tasks.Signature, taskResults []
 		signature.GroupTaskCount,
 	)
 	if err != nil {
-		return fmt.Errorf("GroupCompleted: %v", err)
+		return fmt.Errorf("Group completed error: %v", err)
 	}
 	// If the group has not yet completed, just return
 	if !groupCompleted {
@@ -162,7 +192,7 @@ func (worker *Worker) finalizeSuccess(signature *tasks.Signature, taskResults []
 
 	// Defer purging of group meta queue if we are using AMQP backend
 	if worker.hasAMQPBackend() {
-		defer worker.server.backend.PurgeGroupMeta(signature.GroupUUID)
+		defer worker.server.GetBackend().PurgeGroupMeta(signature.GroupUUID)
 	}
 
 	// There is no chord callback, just return
@@ -171,9 +201,9 @@ func (worker *Worker) finalizeSuccess(signature *tasks.Signature, taskResults []
 	}
 
 	// Trigger chord callback
-	shouldTrigger, err := worker.server.backend.TriggerChord(signature.GroupUUID)
+	shouldTrigger, err := worker.server.GetBackend().TriggerChord(signature.GroupUUID)
 	if err != nil {
-		return fmt.Errorf("TriggerChord: %v", err)
+		return fmt.Errorf("Trigger chord error: %v", err)
 	}
 
 	// Chord has already been triggered
@@ -216,29 +246,24 @@ func (worker *Worker) finalizeSuccess(signature *tasks.Signature, taskResults []
 	return nil
 }
 
-// Task failed, update state and trigger error callbacks
-func (worker *Worker) finalizeError(signature *tasks.Signature, err error) error {
+// taskFailed updates the task state and triggers error callbacks
+func (worker *Worker) taskFailed(signature *tasks.Signature, taskErr error) error {
 	// Update task state to FAILURE
-	backend := worker.server.GetBackend()
-	if err1 := backend.SetStateFailure(signature, err.Error()); err1 != nil {
-		return fmt.Errorf("Set State Failure: %v", err1)
+	if err := worker.server.GetBackend().SetStateFailure(signature, taskErr.Error()); err != nil {
+		return fmt.Errorf("Set state failure error: %v", err)
 	}
 
-	log.ERROR.Printf("Failed processing %s. Error = %v", signature.UUID, err)
+	log.ERROR.Printf("Failed processing %s. Error = %v", signature.UUID, taskErr)
 
 	// Trigger error callbacks
 	for _, errorTask := range signature.OnError {
 		// Pass error as a first argument to error callbacks
 		args := append([]tasks.Arg{{
 			Type:  "string",
-			Value: err.Error(),
+			Value: taskErr.Error(),
 		}}, errorTask.Args...)
 		errorTask.Args = args
 		worker.server.SendTask(errorTask)
-	}
-
-	if signature.RetryCount > 0 {
-		signature.RetryCount--
 	}
 
 	return nil
@@ -246,6 +271,6 @@ func (worker *Worker) finalizeError(signature *tasks.Signature, err error) error
 
 // Returns true if the worker uses AMQP backend
 func (worker *Worker) hasAMQPBackend() bool {
-	_, ok := worker.server.backend.(*backends.AMQPBackend)
+	_, ok := worker.server.GetBackend().(*backends.AMQPBackend)
 	return ok
 }

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -237,6 +237,10 @@ func (worker *Worker) finalizeError(signature *tasks.Signature, err error) error
 		worker.server.SendTask(errorTask)
 	}
 
+	if signature.RetryCount > 0 {
+		signature.RetryCount--
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR aims to provide a basic retry functionality for failed tasks.

By default, failed tasks will not retry. Optionally, it will be possible to set `Signature.RetryCount` parameter to > 0 to make machinery retry failed tasks.

Progress:
- added a new `RETRY` state
- added `RetryCount` parameter to signature.