### PR TITLE
Set read and write timeouts on the redis connection

### DIFF
--- a/v1/common/redis.go
+++ b/v1/common/redis.go
@@ -42,7 +42,12 @@ func (rc *RedisConnector) NewPool(socketPath, host, password string, db int) *re
 
 // Open a new Redis connection
 func (rc *RedisConnector) open(socketPath, host, password string, db int) (redis.Conn, error) {
-	var opts = []redis.DialOption{redis.DialDatabase(db)}
+	var opts = []redis.DialOption{
+		redis.DialDatabase(db),
+		redis.DialReadTimeout(15 * time.Second),
+		redis.DialWriteTimeout(15 * time.Second),
+		redis.DialConnectTimeout(15 * time.Second),
+	}
 
 	if password != "" {
 		opts = append(opts, redis.DialPassword(password))


### PR DESCRIPTION
First of all, thanks for writing Machinery, it's been a pleasure to use.

We've been running Machinery to schedule tasks for execution at a later time, using Redis as a broker. After running for a couple of days without restarting we have noticed no new tasks being picked up, even though they are scheduled for execution at those times. We don't get any errors, it just stops consuming.

I suspect that this could happen due to the redis connection hanging on read or write, and I figured it would be a good idea to set a timeout on those.