### PR TITLE
Fix outdated config example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,19 +230,19 @@ import (
   "github.com/RichardKnop/machinery/v1"
 )
 
-var cnf = config.Config{
+var cnf = &config.Config{
   Broker:             "amqp://guest:guest@localhost:5672/",
+  DefaultQueue:       "machinery_tasks",
   ResultBackend:      "amqp://guest:guest@localhost:5672/",
   MaxWorkerInstances: 0,
-  AMQP:               config.AMQPConfig{
+  AMQP:               &config.AMQPConfig{
     Exchange:     "machinery_exchange",
     ExchangeType: "direct",
-    DefaultQueue: "machinery_tasks",
     BindingKey:   "machinery_task",
   },
 }
 
-server, err := machinery.NewServer(&cnf)
+server, err := machinery.NewServer(cnf)
 if err != nil {
   // do something with the error
 }


### PR DESCRIPTION
Hi! I corrected some lines on configuration example in README.

`Conifg.AMQP` value should be `*AMQPConfig` type and `DefaultQueue` is field of `Config` not `AMQPConfig`.