### PR TITLE
Add support for concurrency per worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ var cnf = &config.Config{
   Broker:             "amqp://guest:guest@localhost:5672/",
   DefaultQueue:       "machinery_tasks",
   ResultBackend:      "amqp://guest:guest@localhost:5672/",
-  MaxWorkerInstances: 0,
   AMQP:               &config.AMQPConfig{
     Exchange:     "machinery_exchange",
     ExchangeType: "direct",
@@ -253,7 +252,7 @@ if err != nil {
 In order to consume tasks, you need to have one or more workers running. All you need to run a worker is a `Server` instance with registered tasks. E.g.:
 
 ```go
-worker := server.NewWorker("worker_name")
+worker := server.NewWorker("worker_name", 10)
 err := worker.Launch()
 if err != nil {
   // do something with the error
@@ -261,9 +260,8 @@ if err != nil {
 ```
 
 Each worker will only consume registered tasks. For each task on the queue the Worker.Process() method will will be run
-in a goroutine. Use the `MaxWorkerInstances` config option to limit the number of concurrently running Worker.Process()
-calls (per worker). `MaxWorkerInstances = 1` will serialize task execution. `MaxWorkerInstances = 0` makes the number of
-concurrently executed tasks unlimited (default).
+in a goroutine. Use the second parameter of `server.NewWorker` to limit the number of concurrently running Worker.Process()
+calls (per worker). Example: 1 will serialize task execution while 0 makes the number of concurrently executed tasks unlimited (default).
 
 ### Tasks
 

--- a/example/machinery.go
+++ b/example/machinery.go
@@ -181,7 +181,7 @@ func send() error {
 	initTasks()
 	log.INFO.Println("Single task:")
 
-	asyncResult, err := server.SendTask(&task0)
+	asyncResult, err := server.SendTask(&task0, false)
 	if err != nil {
 		return fmt.Errorf("Could not send task: %s", err.Error())
 	}
@@ -254,7 +254,7 @@ func send() error {
 
 	// Let's try a task which throws panic to make sure stack trace is not lost
 	initTasks()
-	asyncResult, err = server.SendTask(&task5)
+	asyncResult, err = server.SendTask(&task5, false)
 	if err != nil {
 		return fmt.Errorf("Could not send task: %s", err.Error())
 	}

--- a/example/machinery.go
+++ b/example/machinery.go
@@ -96,7 +96,7 @@ func worker() error {
 
 	// The second argument is a consumer tag
 	// Ideally, each worker should have a unique tag (worker1, worker2 etc)
-	worker := server.NewWorker("machinery_worker")
+	worker := server.NewWorker("machinery_worker", 0)
 
 	if err := worker.Launch(); err != nil {
 		return err

--- a/integration-tests/amqp_amqp_test.go
+++ b/integration-tests/amqp_amqp_test.go
@@ -25,7 +25,7 @@ func TestAmqpAmqp(t *testing.T) {
 			PrefetchCount: 1,
 		},
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/amqp_memcache_test.go
+++ b/integration-tests/amqp_memcache_test.go
@@ -27,7 +27,7 @@ func TestAmqpMemcache(t *testing.T) {
 			PrefetchCount: 1,
 		},
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/amqp_mongodb_test.go
+++ b/integration-tests/amqp_mongodb_test.go
@@ -27,7 +27,7 @@ func TestAmqpMongodb(t *testing.T) {
 			PrefetchCount: 1,
 		},
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/amqp_redis_test.go
+++ b/integration-tests/amqp_redis_test.go
@@ -27,7 +27,7 @@ func TestAmqpRedis(t *testing.T) {
 			PrefetchCount: 1,
 		},
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/eager_eager_test.go
+++ b/integration-tests/eager_eager_test.go
@@ -59,7 +59,7 @@ func (s *EagerIntegrationTestSuite) TestCalled() {
 				Value: 100.0,
 			},
 		},
-	})
+	}, false)
 
 	s.Nil(err)
 	s.Equal(100.0, s.called)
@@ -76,7 +76,7 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 					Value: 100.0,
 				},
 			},
-		})
+		}, false)
 
 		s.NotNil(asyncResult)
 		s.Nil(err)
@@ -107,7 +107,7 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 					Value: 100,
 				},
 			},
-		})
+		}, false)
 
 		s.NotNil(asyncResult)
 		s.Nil(err)

--- a/integration-tests/redis_memcache_test.go
+++ b/integration-tests/redis_memcache_test.go
@@ -21,7 +21,7 @@ func TestRedisMemcache(t *testing.T) {
 		DefaultQueue:  "test_queue",
 		ResultBackend: fmt.Sprintf("memcache://%v", memcacheURL),
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/redis_mongodb_test.go
+++ b/integration-tests/redis_mongodb_test.go
@@ -21,7 +21,7 @@ func TestRedisMongodb(t *testing.T) {
 		DefaultQueue:  "test_queue",
 		ResultBackend: fmt.Sprintf("mongodb://%v", mongodbURL),
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -20,7 +20,7 @@ func TestRedisRedis(t *testing.T) {
 		DefaultQueue:  "test_queue",
 		ResultBackend: fmt.Sprintf("redis://%v", redisURL),
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/redis_socket_test.go
+++ b/integration-tests/redis_socket_test.go
@@ -20,7 +20,7 @@ func TestRedisSocket(t *testing.T) {
 		DefaultQueue:  "test_queue",
 		ResultBackend: fmt.Sprintf("redis+socket://%v", redisSocket),
 	})
-	worker := server.NewWorker("test_worker")
+	worker := server.NewWorker("test_worker", 0)
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()

--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -34,7 +34,7 @@ func testAll(server *machinery.Server, t *testing.T) {
 func testSendTask(server *machinery.Server, t *testing.T) {
 	addTask := newAddTask(1, 1)
 
-	asyncResult, err := server.SendTask(addTask)
+	asyncResult, err := server.SendTask(addTask, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -156,7 +156,7 @@ func testSendChord(server *machinery.Server, t *testing.T) {
 func testReturnJustError(server *machinery.Server, t *testing.T) {
 	// Fails, returns error as the only value
 	task := newErrorTask("Test error", true)
-	asyncResult, err := server.SendTask(task)
+	asyncResult, err := server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -169,7 +169,7 @@ func testReturnJustError(server *machinery.Server, t *testing.T) {
 
 	// Successful, returns nil as the only value
 	task = newErrorTask("", false)
-	asyncResult, err = server.SendTask(task)
+	asyncResult, err = server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -185,7 +185,7 @@ func testReturnMultipleValues(server *machinery.Server, t *testing.T) {
 	// Successful task with multiple return values
 	task := newMultipleReturnTask("foo", "bar", false)
 
-	asyncResult, err := server.SendTask(task)
+	asyncResult, err := server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,7 +218,7 @@ func testReturnMultipleValues(server *machinery.Server, t *testing.T) {
 	// Failed task with multiple return values
 	task = newMultipleReturnTask("", "", true)
 
-	asyncResult, err = server.SendTask(task)
+	asyncResult, err = server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -232,7 +232,7 @@ func testReturnMultipleValues(server *machinery.Server, t *testing.T) {
 
 func testPanic(server *machinery.Server, t *testing.T) {
 	task := &tasks.Signature{Name: "panic"}
-	asyncResult, err := server.SendTask(task)
+	asyncResult, err := server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -248,7 +248,7 @@ func testDelay(server *machinery.Server, t *testing.T) {
 	now := time.Now().UTC()
 	eta := now.Add(100 * (time.Millisecond))
 	task := newDelayTask(eta)
-	asyncResult, err := server.SendTask(task)
+	asyncResult, err := server.SendTask(task, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/integration-tests/worker_only_consumes_registered_tasks_test.go
+++ b/integration-tests/worker_only_consumes_registered_tasks_test.go
@@ -85,8 +85,8 @@ func TestWorkerOnlyConsumesRegisteredTaskAMQP(t *testing.T) {
 		},
 	}
 
-	worker1 := server1.NewWorker("test_worker")
-	worker2 := server2.NewWorker("test_worker2")
+	worker1 := server1.NewWorker("test_worker", 0)
+	worker2 := server2.NewWorker("test_worker2", 0)
 	go worker1.Launch()
 	go worker2.Launch()
 
@@ -196,8 +196,8 @@ func TestWorkerOnlyConsumesRegisteredTaskRedis(t *testing.T) {
 		},
 	}
 
-	worker1 := server1.NewWorker("test_worker")
-	worker2 := server2.NewWorker("test_worker2")
+	worker1 := server1.NewWorker("test_worker", 0)
+	worker2 := server2.NewWorker("test_worker2", 0)
 	go worker1.Launch()
 	go worker2.Launch()
 

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -84,7 +84,7 @@ func (b *AMQPBroker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
+func (b *AMQPBroker) Publish(signature *tasks.Signature, head bool) error {
 	b.AdjustRoutingKey(signature)
 
 	// Check the ETA signature field, if it is set and it is in the future,

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -26,7 +26,7 @@ func NewAMQPBroker(cnf *config.Config) Interface {
 }
 
 // StartConsuming enters a loop and waits for incoming messages
-func (b *AMQPBroker) StartConsuming(consumerTag string, taskProcessor TaskProcessor) (bool, error) {
+func (b *AMQPBroker) StartConsuming(consumerTag string, concurrency int, taskProcessor TaskProcessor) (bool, error) {
 	b.startConsuming(consumerTag, taskProcessor)
 
 	conn, channel, queue, _, amqpCloseChan, err := b.Connect(
@@ -71,7 +71,7 @@ func (b *AMQPBroker) StartConsuming(consumerTag string, taskProcessor TaskProces
 
 	log.INFO.Print("[*] Waiting for messages. To exit press CTRL+C")
 
-	if err := b.consume(deliveries, taskProcessor, amqpCloseChan); err != nil {
+	if err := b.consume(deliveries, concurrency, taskProcessor, amqpCloseChan); err != nil {
 		return b.retry, err
 	}
 
@@ -148,13 +148,12 @@ func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 
 // consume takes delivered messages from the channel and manages a worker pool
 // to process tasks concurrently
-func (b *AMQPBroker) consume(deliveries <-chan amqp.Delivery, taskProcessor TaskProcessor, amqpCloseChan <-chan *amqp.Error) error {
-	maxWorkers := b.cnf.MaxWorkerInstances
-	pool := make(chan struct{}, maxWorkers)
+func (b *AMQPBroker) consume(deliveries <-chan amqp.Delivery, concurrency int, taskProcessor TaskProcessor, amqpCloseChan <-chan *amqp.Error) error {
+	pool := make(chan struct{}, concurrency)
 
 	// initialize worker pool with maxWorkers workers
 	go func() {
-		for i := 0; i < maxWorkers; i++ {
+		for i := 0; i < concurrency; i++ {
 			pool <- struct{}{}
 		}
 	}()
@@ -172,7 +171,7 @@ func (b *AMQPBroker) consume(deliveries <-chan amqp.Delivery, taskProcessor Task
 		case err := <-errorsChan:
 			return err
 		case d := <-deliveries:
-			if maxWorkers != 0 {
+			if concurrency != 0 {
 				// get worker from pool (blocks until one is available)
 				<-pool
 			}
@@ -188,7 +187,7 @@ func (b *AMQPBroker) consume(deliveries <-chan amqp.Delivery, taskProcessor Task
 					errorsChan <- err
 				}
 
-				if maxWorkers != 0 {
+				if concurrency != 0 {
 					// give worker back to pool
 					pool <- struct{}{}
 				}

--- a/v1/brokers/eager.go
+++ b/v1/brokers/eager.go
@@ -25,7 +25,7 @@ type EagerMode interface {
 }
 
 // StartConsuming enters a loop and waits for incoming messages
-func (eagerBroker *EagerBroker) StartConsuming(consumerTag string, p TaskProcessor) (bool, error) {
+func (eagerBroker *EagerBroker) StartConsuming(consumerTag string, concurrency int, p TaskProcessor) (bool, error) {
 	return true, nil
 }
 

--- a/v1/brokers/eager.go
+++ b/v1/brokers/eager.go
@@ -35,7 +35,7 @@ func (eagerBroker *EagerBroker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (eagerBroker *EagerBroker) Publish(task *tasks.Signature) error {
+func (eagerBroker *EagerBroker) Publish(task *tasks.Signature, head bool) error {
 	if eagerBroker.worker == nil {
 		return errors.New("worker is not assigned in eager-mode")
 	}

--- a/v1/brokers/interfaces.go
+++ b/v1/brokers/interfaces.go
@@ -10,7 +10,7 @@ type Interface interface {
 	IsTaskRegistered(name string) bool
 	StartConsuming(consumerTag string, concurrency int, p TaskProcessor) (bool, error)
 	StopConsuming()
-	Publish(task *tasks.Signature) error
+	Publish(task *tasks.Signature, head bool) error
 	GetPendingTasks(queue string) ([]*tasks.Signature, error)
 }
 

--- a/v1/brokers/interfaces.go
+++ b/v1/brokers/interfaces.go
@@ -8,7 +8,7 @@ import (
 type Interface interface {
 	SetRegisteredTaskNames(names []string)
 	IsTaskRegistered(name string) bool
-	StartConsuming(consumerTag string, p TaskProcessor) (bool, error)
+	StartConsuming(consumerTag string, concurrency int, p TaskProcessor) (bool, error)
 	StopConsuming()
 	Publish(task *tasks.Signature) error
 	GetPendingTasks(queue string) ([]*tasks.Signature, error)

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -132,7 +132,7 @@ func (b *RedisBroker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (b *RedisBroker) Publish(signature *tasks.Signature) error {
+func (b *RedisBroker) Publish(signature *tasks.Signature, head bool) error {
 	msg, err := json.Marshal(signature)
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
@@ -155,7 +155,12 @@ func (b *RedisBroker) Publish(signature *tasks.Signature) error {
 		}
 	}
 
-	_, err = conn.Do("RPUSH", signature.RoutingKey, msg)
+	if head {
+		_, err = conn.Do("LPUSH", signature.RoutingKey, msg)
+	} else {
+		_, err = conn.Do("RPUSH", signature.RoutingKey, msg)
+	}
+
 	return err
 }
 

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -45,7 +45,7 @@ func NewRedisBroker(cnf *config.Config, host, password, socketPath string, db in
 }
 
 // StartConsuming enters a loop and waits for incoming messages
-func (b *RedisBroker) StartConsuming(consumerTag string, taskProcessor TaskProcessor) (bool, error) {
+func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskProcessor TaskProcessor) (bool, error) {
 	b.startConsuming(consumerTag, taskProcessor)
 
 	conn := b.open()
@@ -113,7 +113,7 @@ func (b *RedisBroker) StartConsuming(consumerTag string, taskProcessor TaskProce
 		}
 	}()
 
-	if err := b.consume(deliveries, taskProcessor); err != nil {
+	if err := b.consume(deliveries, concurrency, taskProcessor); err != nil {
 		return b.retry, err
 	}
 
@@ -189,13 +189,12 @@ func (b *RedisBroker) GetPendingTasks(queue string) ([]*tasks.Signature, error) 
 
 // consume takes delivered messages from the channel and manages a worker pool
 // to process tasks concurrently
-func (b *RedisBroker) consume(deliveries <-chan []byte, taskProcessor TaskProcessor) error {
-	maxWorkers := b.cnf.MaxWorkerInstances
-	pool := make(chan struct{}, maxWorkers)
+func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskProcessor TaskProcessor) error {
+	pool := make(chan struct{}, concurrency)
 
 	// initialize worker pool with maxWorkers workers
 	go func() {
-		for i := 0; i < maxWorkers; i++ {
+		for i := 0; i < concurrency; i++ {
 			pool <- struct{}{}
 		}
 	}()
@@ -211,7 +210,7 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, taskProcessor TaskProces
 		case err := <-errorsChan:
 			return err
 		case d := <-deliveries:
-			if maxWorkers != 0 {
+			if concurrency != 0 {
 				// get worker from pool (blocks until one is available)
 				<-pool
 			}
@@ -227,7 +226,7 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, taskProcessor TaskProces
 					errorsChan <- err
 				}
 
-				if maxWorkers != 0 {
+				if concurrency != 0 {
 					// give worker back to pool
 					pool <- struct{}{}
 				}

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -10,11 +10,10 @@ import (
 var (
 	// Start with sensible default values
 	cnf = &Config{
-		Broker:             "amqp://guest:guest@localhost:5672/",
-		DefaultQueue:       "machinery_tasks",
-		ResultBackend:      "amqp://guest:guest@localhost:5672/",
-		ResultsExpireIn:    3600,
-		MaxWorkerInstances: 3,
+		Broker:          "amqp://guest:guest@localhost:5672/",
+		DefaultQueue:    "machinery_tasks",
+		ResultBackend:   "amqp://guest:guest@localhost:5672/",
+		ResultsExpireIn: 3600,
 		AMQP: &AMQPConfig{
 			Exchange:      "machinery_exchange",
 			ExchangeType:  "direct",
@@ -30,13 +29,12 @@ var (
 
 // Config holds all configuration for our program
 type Config struct {
-	Broker             string      `yaml:"broker" envconfig:"BROKER"`
-	DefaultQueue       string      `yaml:"default_queue" envconfig:"DEFAULT_QUEUE"`
-	ResultBackend      string      `yaml:"result_backend" envconfig:"RESULT_BACKEND"`
-	ResultsExpireIn    int         `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
-	MaxWorkerInstances int         `yaml:"max_worker_instances" envconfig:"MAX_WORKER_INSTANCES"`
-	AMQP               *AMQPConfig `yaml:"amqp"`
-	TLSConfig          *tls.Config
+	Broker          string      `yaml:"broker" envconfig:"BROKER"`
+	DefaultQueue    string      `yaml:"default_queue" envconfig:"DEFAULT_QUEUE"`
+	ResultBackend   string      `yaml:"result_backend" envconfig:"RESULT_BACKEND"`
+	ResultsExpireIn int         `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
+	AMQP            *AMQPConfig `yaml:"amqp"`
+	TLSConfig       *tls.Config
 }
 
 // QueueBindingArgs arguments which are used when binding to the exchange

--- a/v1/config/env_test.go
+++ b/v1/config/env_test.go
@@ -34,7 +34,6 @@ func TestNewFromEnvironment(t *testing.T) {
 	assert.Equal(t, "machinery_tasks", cnf.DefaultQueue)
 	assert.Equal(t, "amqp", cnf.ResultBackend)
 	assert.Equal(t, 3600000, cnf.ResultsExpireIn)
-	assert.Equal(t, 10, cnf.MaxWorkerInstances)
 	assert.Equal(t, "machinery_exchange", cnf.AMQP.Exchange)
 	assert.Equal(t, "direct", cnf.AMQP.ExchangeType)
 	assert.Equal(t, "machinery_task", cnf.AMQP.BindingKey)

--- a/v1/config/file_test.go
+++ b/v1/config/file_test.go
@@ -12,7 +12,6 @@ import (
 var configYAMLData = `---
 broker: "amqp://guest:guest@localhost:5672/"
 default_queue: machinery_tasks
-max_worker_instances: 10
 result_backend: amqp
 results_expire_in: 3600000
 amqp:
@@ -49,7 +48,6 @@ func TestNewFromYaml(t *testing.T) {
 	assert.Equal(t, "machinery_tasks", cnf.DefaultQueue)
 	assert.Equal(t, "amqp", cnf.ResultBackend)
 	assert.Equal(t, 3600000, cnf.ResultsExpireIn)
-	assert.Equal(t, 10, cnf.MaxWorkerInstances)
 	assert.Equal(t, "machinery_exchange", cnf.AMQP.Exchange)
 	assert.Equal(t, "direct", cnf.AMQP.ExchangeType)
 	assert.Equal(t, "machinery_task", cnf.AMQP.BindingKey)

--- a/v1/config/testconfig.yml
+++ b/v1/config/testconfig.yml
@@ -1,7 +1,6 @@
 ---
 broker: "amqp://guest:guest@localhost:5672/"
 default_queue: machinery_tasks
-max_worker_instances: 10
 result_backend: amqp
 results_expire_in: 3600000
 amqp:

--- a/v1/server.go
+++ b/v1/server.go
@@ -126,7 +126,7 @@ func (server *Server) GetRegisteredTask(name string) (interface{}, error) {
 }
 
 // SendTask publishes a task to the default queue
-func (server *Server) SendTask(signature *tasks.Signature) (*backends.AsyncResult, error) {
+func (server *Server) SendTask(signature *tasks.Signature, head bool) (*backends.AsyncResult, error) {
 	// Make sure result backend is defined
 	if server.backend == nil {
 		return nil, errors.New("Result backend required")
@@ -142,7 +142,7 @@ func (server *Server) SendTask(signature *tasks.Signature) (*backends.AsyncResul
 		return nil, fmt.Errorf("Set state pending error: %s", err)
 	}
 
-	if err := server.broker.Publish(signature); err != nil {
+	if err := server.broker.Publish(signature, head); err != nil {
 		return nil, fmt.Errorf("Publish message error: %s", err)
 	}
 
@@ -151,7 +151,7 @@ func (server *Server) SendTask(signature *tasks.Signature) (*backends.AsyncResul
 
 // SendChain triggers a chain of tasks
 func (server *Server) SendChain(chain *tasks.Chain) (*backends.ChainAsyncResult, error) {
-	_, err := server.SendTask(chain.Tasks[0])
+	_, err := server.SendTask(chain.Tasks[0], false)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (server *Server) SendGroup(group *tasks.Group) ([]*backends.AsyncResult, er
 			}
 
 			// Publish task
-			if err := server.broker.Publish(s); err != nil {
+			if err := server.broker.Publish(s, false); err != nil {
 				errorsChan <- fmt.Errorf("Publish message error: %s", err)
 				return
 			}

--- a/v1/server.go
+++ b/v1/server.go
@@ -43,17 +43,18 @@ func NewServer(cnf *config.Config) (*Server, error) {
 	if ok {
 		// we don't have to call worker.Lauch
 		// in eager mode
-		eager.AssignWorker(srv.NewWorker("eager"))
+		eager.AssignWorker(srv.NewWorker("eager", 0))
 	}
 
 	return srv, nil
 }
 
 // NewWorker creates Worker instance
-func (server *Server) NewWorker(consumerTag string) *Worker {
+func (server *Server) NewWorker(consumerTag string, concurrency int) *Worker {
 	return &Worker{
 		server:      server,
 		ConsumerTag: consumerTag,
+		Concurrency: concurrency,
 	}
 }
 

--- a/v1/tasks/workflow.go
+++ b/v1/tasks/workflow.go
@@ -8,7 +8,8 @@ import (
 
 // Chain creates a chain of tasks to be executed one after another
 type Chain struct {
-	Tasks []*Signature
+	Tasks    []*Signature
+	Priority bool
 }
 
 // Group creates a set of tasks to be executed in parallel

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -138,7 +138,7 @@ func (worker *Worker) taskRetry(signature *tasks.Signature) error {
 	log.WARNING.Printf("Task %s failed. Going to retry in %ds.", signature.UUID, signature.RetryTimeout)
 
 	// Send the task back to the queue
-	_, err := worker.server.SendTask(signature)
+	_, err := worker.server.SendTask(signature, false)
 	return err
 }
 
@@ -171,7 +171,7 @@ func (worker *Worker) taskSucceeded(signature *tasks.Signature, taskResults []*t
 			successTask.Args = append(args, successTask.Args...)
 		}
 
-		worker.server.SendTask(successTask)
+		worker.server.SendTask(successTask, true)
 	}
 
 	// If the task was not part of a group, just return
@@ -240,7 +240,7 @@ func (worker *Worker) taskSucceeded(signature *tasks.Signature, taskResults []*t
 	}
 
 	// Send the chord task
-	_, err = worker.server.SendTask(signature.ChordCallback)
+	_, err = worker.server.SendTask(signature.ChordCallback, false)
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (worker *Worker) taskFailed(signature *tasks.Signature, taskErr error) erro
 			Value: taskErr.Error(),
 		}}, errorTask.Args...)
 		errorTask.Args = args
-		worker.server.SendTask(errorTask)
+		worker.server.SendTask(errorTask, false)
 	}
 
 	return nil

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -19,6 +19,7 @@ import (
 type Worker struct {
 	server      *Server
 	ConsumerTag string
+	Concurrency int
 }
 
 // Launch starts a new worker process. The worker subscribes
@@ -45,7 +46,7 @@ func (worker *Worker) Launch() error {
 
 	go func() {
 		for {
-			retry, err := broker.StartConsuming(worker.ConsumerTag, worker)
+			retry, err := broker.StartConsuming(worker.ConsumerTag, worker.Concurrency, worker)
 
 			if retry {
 				log.WARNING.Printf("Start consuming error: %s", err)


### PR DESCRIPTION
Hi,

as described in my comment in #111 I refactored the global `MaxWorkerInstances` config into a separate Worker attribute.

This way we can set different concurrencies for different workers. This is already part of many other worker packages.

Unfortunately this is a breaking change, so I will let you decide if and how you want to integrate it.

Cheers

