### PR TITLE
I found some bugs

### DIFF
--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -48,6 +48,7 @@ func NewRedisBroker(cnf *config.Config, host, password, socketPath string, db in
 func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskProcessor TaskProcessor) (bool, error) {
 	b.startConsuming(consumerTag, taskProcessor)
 
+	b.pool = nil
 	conn := b.open()
 	defer conn.Close()
 	defer b.pool.Close()
@@ -199,7 +200,8 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskPro
 		}
 	}()
 
-	errorsChan := make(chan error)
+	errorsChan := make(chan error, concurrency*2)
+	//errorsChan := make(chan error)
 
 	// Use wait group to make sure task processing completes on interrupt signal
 	var wg sync.WaitGroup

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -185,6 +185,7 @@ func (worker *Worker) taskSucceeded(signature *tasks.Signature, taskResults []*t
 	if err != nil {
 		return fmt.Errorf("Group completed error: %s", err)
 	}
+
 	// If the group has not yet completed, just return
 	if !groupCompleted {
 		return nil


### PR DESCRIPTION
Hi, I think I found some bugs, and tried to fix them.

Bug1:  If we send a group with many tasks, and the sending process is not  finished. While some of the previous sent tasks have finished, they will  use the getStates() function to check the group status and will  return an error. This will lead the "brokers/redis.go" consume()  function exit and leave the other tasks stay in the Redis forever. 

Bug2:The SendGroup() function has no pool mechanism, which will cause crash when there are many tasks in one group.

Bug3: brokers/redis.go consume() function (about L200) , there is a dead lock condition.If there some routines failed, they will wait at "errorChan <- err" . The main process will get a err from one of the routines, and before return , it will wait at   "defer wg.Wait()". This is a dead lock.

﻿﻿Bug 4: When restart StartConsuming(), the "b.pool" is close, but its value isn't nil. In the next try, because it isn't nil, the pool will not be reassigned.  This will lead every restart StartConsuming() failed.


