### PR TITLE
Fix pool logic to handle concurrency in SendGroup call.

### DIFF
--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -22,7 +22,8 @@ func (a ascendingInt64s) Less(i, j int) bool { return a[i] < a[j] }
 
 func testAll(server *machinery.Server, t *testing.T) {
 	testSendTask(server, t)
-	testSendGroup(server, t)
+	testSendGroup(server, t, 0) // with unlimited concurrency
+	testSendGroup(server, t, 2) // with limited concurrency (2 parallel tasks at the most)
 	testSendChord(server, t)
 	testSendChain(server, t)
 	testReturnJustError(server, t)
@@ -57,11 +58,11 @@ func testSendTask(server *machinery.Server, t *testing.T) {
 	}
 }
 
-func testSendGroup(server *machinery.Server, t *testing.T) {
+func testSendGroup(server *machinery.Server, t *testing.T, sendConcurrency int) {
 	t1, t2, t3 := newAddTask(1, 1), newAddTask(2, 2), newAddTask(5, 6)
 
 	group := tasks.NewGroup(t1, t2, t3)
-	asyncResults, err := server.SendGroup(group, 10)
+	asyncResults, err := server.SendGroup(group, sendConcurrency)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Currently there is a bug in SendGroup pooling logic which means all tasks will be sent synchronously irrespective of the concurrency parameter sent to the method.

See this issue: https://github.com/RichardKnop/machinery/issues/172