### PR TITLE
fix err chan size in server.go

### DIFF
--- a/v1/server.go
+++ b/v1/server.go
@@ -170,7 +170,7 @@ func (server *Server) SendGroup(group *tasks.Group, sendConcurrency int) ([]*bac
 
 	var wg sync.WaitGroup
 	wg.Add(len(group.Tasks))
-	errorsChan := make(chan error)
+	errorsChan := make(chan error, len(group.Tasks)*2)
 
 	// Init group
 	server.backend.InitGroup(group.GroupUUID, group.GetUUIDs())


### PR DESCRIPTION
Hi, I found a problem in the SendGroup.
The length of errorsChan in SendGroup function is 1. Once more than one error happen, the main program or some routine will block. 
The max number of errors can happen in this section is 2*len(group.Tasks). So I change the size to it.
I'm not sure if it is very good. So please confirm it. Thanks very much.