### PR TITLE
change order of appended arguments on success

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -162,10 +162,10 @@ func (worker *Worker) taskSucceeded(signature *tasks.Signature, taskResults []*t
 		if signature.Immutable == false {
 			// Pass results of the task to success callbacks
 			for _, taskResult := range taskResults {
-				successTask.Args = append([]tasks.Arg{{
+				successTask.Args = append(successTask.Args, tasks.Arg{
 					Type:  taskResult.Type,
 					Value: taskResult.Value,
-				}}, successTask.Args...)
+				})
 			}
 		}
 


### PR DESCRIPTION
Playing around with machinery chains, I found that in some cases appending the result value of a task at the beginning of the arguments slice used to execute the next task, can result on unexpected issues if the position of the arguments is important for the function and the result of the previous one is not being considered or is wanted as an optional argument.

So, I propose to change the append order of those arguments or maybe have an optional parameter to allow the user to choose if they want them at the beginning or the end of the slice ?

Let me know your thoughts.

Thanks