### PR TITLE
Wait for running tasks to finish when quitting a worker.

### DIFF
--- a/example/tasks/tasks.go
+++ b/example/tasks/tasks.go
@@ -2,6 +2,9 @@ package exampletasks
 
 import (
 	"errors"
+	"time"
+
+	"github.com/RichardKnop/machinery/v1/log"
 )
 
 // Add ...
@@ -25,4 +28,15 @@ func Multiply(args ...int64) (int64, error) {
 // PanicTask ...
 func PanicTask() (string, error) {
 	panic(errors.New("oops"))
+}
+
+// LongRunningTask ...
+func LongRunningTask() error {
+	log.INFO.Print("Long running task started")
+	for i := 0; i < 10; i++ {
+		log.INFO.Print(10 - i)
+		<-time.After(1 * time.Second)
+	}
+	log.INFO.Print("Long running task finished")
+	return nil
 }

--- a/v1/backends/async_result.go
+++ b/v1/backends/async_result.go
@@ -98,12 +98,12 @@ func (asyncResult *AsyncResult) Touch() ([]reflect.Value, error) {
 // Get returns task results (synchronous blocking call)
 func (asyncResult *AsyncResult) Get(sleepDuration time.Duration) ([]reflect.Value, error) {
 	for {
-		result, err := asyncResult.Touch()
+		results, err := asyncResult.Touch()
 
-		if result == nil && err == nil {
+		if results == nil && err == nil {
 			<-time.After(sleepDuration)
 		} else {
-			return result, err
+			return results, err
 		}
 	}
 }
@@ -117,12 +117,12 @@ func (asyncResult *AsyncResult) GetWithTimeout(timeoutDuration, sleepDuration ti
 		case <-timeout.C:
 			return nil, errors.New("Timeout reached")
 		default:
-			result, err := asyncResult.Touch()
+			results, err := asyncResult.Touch()
 
-			if result == nil && err == nil {
+			if results == nil && err == nil {
 				<-time.After(sleepDuration)
 			} else {
-				return result, err
+				return results, err
 			}
 		}
 	}

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -24,6 +24,7 @@ type RedisBroker struct {
 	pool              *redis.Pool
 	stopReceivingChan chan int
 	stopDelayedChan   chan int
+	processingWG      sync.WaitGroup // use wait group to make sure task processing completes on interrupt signal
 	receivingWG       sync.WaitGroup
 	delayedWG         sync.WaitGroup
 	// If set, path to a socket file overrides hostname
@@ -118,18 +119,28 @@ func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskPr
 		return b.retry, err
 	}
 
+	// Waiting for any tasks being processed to finish
+	b.processingWG.Wait()
+
 	return b.retry, nil
 }
 
 // StopConsuming quits the loop
 func (b *RedisBroker) StopConsuming() {
+	b.stopConsuming()
+
 	// Stop the receiving goroutine
-	b.stopReceiving()
+	b.stopReceivingChan <- 1
+	// Waiting for the receiving goroutine to have stopped
+	b.receivingWG.Wait()
 
 	// Stop the delayed tasks goroutine
-	b.stopDelayed()
+	b.stopDelayedChan <- 1
+	// Waiting for the delayed tasks goroutine to have stopped
+	b.delayedWG.Wait()
 
-	b.stopConsuming()
+	// Waiting for any tasks being processed to finish
+	b.processingWG.Wait()
 }
 
 // Publish places a new message on the default queue
@@ -201,11 +212,6 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskPro
 	}()
 
 	errorsChan := make(chan error, concurrency*2)
-	//errorsChan := make(chan error)
-
-	// Use wait group to make sure task processing completes on interrupt signal
-	var wg sync.WaitGroup
-	defer wg.Wait()
 
 	for {
 		select {
@@ -217,16 +223,16 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskPro
 				<-pool
 			}
 
-			wg.Add(1)
+			b.processingWG.Add(1)
 
 			// Consume the task inside a gotourine so multiple tasks
 			// can be processed concurrently
 			go func() {
-				defer wg.Done()
-
 				if err := b.consumeOne(d, taskProcessor); err != nil {
 					errorsChan <- err
 				}
+
+				b.processingWG.Done()
 
 				if concurrency > 0 {
 					// give worker back to pool
@@ -241,8 +247,6 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskPro
 
 // consumeOne processes a single message using TaskProcessor
 func (b *RedisBroker) consumeOne(delivery []byte, taskProcessor TaskProcessor) error {
-	log.INFO.Printf("Received new message: %s", delivery)
-
 	sig := new(tasks.Signature)
 	if err := json.Unmarshal(delivery, sig); err != nil {
 		return err
@@ -257,6 +261,8 @@ func (b *RedisBroker) consumeOne(delivery []byte, taskProcessor TaskProcessor) e
 		conn.Do("RPUSH", b.cnf.DefaultQueue, delivery)
 		return nil
 	}
+
+	log.INFO.Printf("Received new message: %s", delivery)
 
 	return taskProcessor.Process(sig)
 }
@@ -344,20 +350,6 @@ func (b *RedisBroker) nextDelayedTask(key string) (result []byte, err error) {
 	}
 
 	return
-}
-
-// Stops the receiving goroutine
-func (b *RedisBroker) stopReceiving() {
-	b.stopReceivingChan <- 1
-	// Waiting for the receiving goroutine to have stopped
-	b.receivingWG.Wait()
-}
-
-// Stops the delayed tasks goroutine
-func (b *RedisBroker) stopDelayed() {
-	b.stopDelayedChan <- 1
-	// Waiting for the delayed tasks goroutine to have stopped
-	b.delayedWG.Wait()
 }
 
 // open returns or creates instance of Redis connection


### PR DESCRIPTION
See: https://github.com/RichardKnop/machinery/issues/194

This PR fixes the worker quitting logic. When there are running tasks and you call `worker.Quit()` method, the process will wait for all running tasks to be processed first before shutting down.

Open to suggestions how to improve this. Should it be made optional? Maybe have an argument to ignore running tasks and quit worker abruptly?

Or if you do `Ctrl+C` two times it should abort without completing running tasks?