### PR TITLE
Redis Delayed Tasks Fix

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -92,7 +92,13 @@ func (b *AMQPBroker) StopConsuming() {
 
 // Publish places a new message on the default queue
 func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
+	// Adjust routing key (this decides which queue the message will be published to)
 	b.AdjustRoutingKey(signature)
+
+	msg, err := json.Marshal(signature)
+	if err != nil {
+		return fmt.Errorf("JSON marshal error: %s", err)
+	}
 
 	// Check the ETA signature field, if it is set and it is in the future,
 	// delay the task
@@ -106,17 +112,12 @@ func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 		}
 	}
 
-	message, err := json.Marshal(signature)
-	if err != nil {
-		return fmt.Errorf("JSON marshal error: %s", err)
-	}
-
 	conn, channel, _, confirmsChan, _, err := b.Connect(
 		b.cnf.Broker,
 		b.cnf.TLSConfig,
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
-		b.cnf.DefaultQueue,      // queue name
+		signature.RoutingKey,    // queue name
 		true,                    // queue durable
 		false,                   // queue delete when unused
 		b.cnf.AMQP.BindingKey, // queue binding key
@@ -137,7 +138,7 @@ func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 		amqp.Publishing{
 			Headers:      amqp.Table(signature.Headers),
 			ContentType:  "application/json",
-			Body:         message,
+			Body:         msg,
 			DeliveryMode: amqp.Persistent,
 		},
 	); err != nil {
@@ -214,7 +215,7 @@ func (b *AMQPBroker) consumeOne(d amqp.Delivery, taskProcessor TaskProcessor) er
 	signature := new(tasks.Signature)
 	if err := json.Unmarshal(d.Body, signature); err != nil {
 		d.Nack(multiple, requeue)
-		return fmt.Errorf("Could not unmarshal '%s'. Error: %s", d.Body, err)
+		return NewErrCouldNotUnmarshaTaskSignature(d.Body, err)
 	}
 
 	// If the task is not registered, we nack it and requeue,

--- a/v1/brokers/errors.go
+++ b/v1/brokers/errors.go
@@ -1,0 +1,21 @@
+package brokers
+
+import (
+	"fmt"
+)
+
+// ErrCouldNotUnmarshaTaskSignature ...
+type ErrCouldNotUnmarshaTaskSignature struct {
+	msg    []byte
+	reason string
+}
+
+// Error implements the error interface
+func (e ErrCouldNotUnmarshaTaskSignature) Error() string {
+	return fmt.Sprintf("Could not unmarshal '%s' into a task signature: %v", e.msg, e.reason)
+}
+
+// NewErrCouldNotUnmarshaTaskSignature returns new NewErrCouldNotUnmarshaTaskSignature instance
+func NewErrCouldNotUnmarshaTaskSignature(msg []byte, err error) ErrCouldNotUnmarshaTaskSignature {
+	return ErrCouldNotUnmarshaTaskSignature{msg: msg, reason: err.Error()}
+}

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -105,12 +105,19 @@ func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskPr
 			case <-b.stopDelayedChan:
 				return
 			default:
-				delayedTask, err := b.nextDelayedTask(redisDelayedTasksKey)
+				task, err := b.nextDelayedTask(redisDelayedTasksKey)
 				if err != nil {
 					continue
 				}
 
-				deliveries <- delayedTask
+				signature := new(tasks.Signature)
+				if err := json.Unmarshal(task, signature); err != nil {
+					log.ERROR.Print(NewErrCouldNotUnmarshaTaskSignature(task, err))
+				}
+
+				if err := b.Publish(signature); err != nil {
+					log.ERROR.Print(err)
+				}
 			}
 		}
 	}()
@@ -145,12 +152,13 @@ func (b *RedisBroker) StopConsuming() {
 
 // Publish places a new message on the default queue
 func (b *RedisBroker) Publish(signature *tasks.Signature) error {
+	// Adjust routing key (this decides which queue the message will be published to)
+	b.AdjustRoutingKey(signature)
+
 	msg, err := json.Marshal(signature)
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
 	}
-
-	b.AdjustRoutingKey(signature)
 
 	conn := b.open()
 	defer conn.Close()
@@ -190,11 +198,11 @@ func (b *RedisBroker) GetPendingTasks(queue string) ([]*tasks.Signature, error) 
 
 	taskSignatures := make([]*tasks.Signature, len(results))
 	for i, result := range results {
-		sig := new(tasks.Signature)
-		if err := json.Unmarshal(result, sig); err != nil {
+		signature := new(tasks.Signature)
+		if err := json.Unmarshal(result, signature); err != nil {
 			return nil, err
 		}
-		taskSignatures[i] = sig
+		taskSignatures[i] = signature
 	}
 	return taskSignatures, nil
 }
@@ -247,14 +255,14 @@ func (b *RedisBroker) consume(deliveries <-chan []byte, concurrency int, taskPro
 
 // consumeOne processes a single message using TaskProcessor
 func (b *RedisBroker) consumeOne(delivery []byte, taskProcessor TaskProcessor) error {
-	sig := new(tasks.Signature)
-	if err := json.Unmarshal(delivery, sig); err != nil {
-		return fmt.Errorf("Could not unmarshal '%s'. Error: %s", delivery, err)
+	signature := new(tasks.Signature)
+	if err := json.Unmarshal(delivery, signature); err != nil {
+		return NewErrCouldNotUnmarshaTaskSignature(delivery, err)
 	}
 
 	// If the task is not registered, we requeue it,
 	// there might be different workers for processing specific tasks
-	if !b.IsTaskRegistered(sig.Name) {
+	if !b.IsTaskRegistered(signature.Name) {
 		conn := b.open()
 		defer conn.Close()
 
@@ -264,7 +272,7 @@ func (b *RedisBroker) consumeOne(delivery []byte, taskProcessor TaskProcessor) e
 
 	log.INFO.Printf("Received new message: %s", delivery)
 
-	return taskProcessor.Process(sig)
+	return taskProcessor.Process(signature)
 }
 
 // nextTask pops next available task from the default queue

--- a/v1/config/env.go
+++ b/v1/config/env.go
@@ -31,7 +31,7 @@ func NewFromEnvironment(keepReloading bool) (*Config, error) {
 				}
 
 				*cnf = *newCnf
-				log.INFO.Printf("Successfully reloaded config from the environment")
+				// log.INFO.Printf("Successfully reloaded config from the environment")
 			}
 		}()
 	}

--- a/v1/config/file.go
+++ b/v1/config/file.go
@@ -33,7 +33,7 @@ func NewFromYaml(cnfPath string, keepReloading bool) (*Config, error) {
 				}
 
 				*cnf = *newCnf
-				log.INFO.Printf("Successfully reloaded config from file %s", cnfPath)
+				// log.INFO.Printf("Successfully reloaded config from file %s", cnfPath)
 			}
 		}()
 	}


### PR DESCRIPTION
Delayed tasks with Redis broker now get routed to a correct queue based on routing key and not just passed to the current worker instance which meant delayed tasks with other than default queue name as routing key would not work.