### PR TITLE
Perform amqp ack after worker processing

### DIFF
--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -231,8 +231,9 @@ func (b *AMQPBroker) consumeOne(d amqp.Delivery, taskProcessor TaskProcessor) er
 
 	log.INFO.Printf("Received new message: %s", d.Body)
 
+	err := taskProcessor.Process(signature)
 	d.Ack(multiple)
-	return taskProcessor.Process(signature)
+	return err
 }
 
 // delay a task by delayDuration miliseconds, the way it works is a new queue


### PR DESCRIPTION
Right now using AMQP is not reliable, because you're perform Ack before worker processing. 
For example if application got SIGKILL, worker will be never restarted.

I guess it is incorrect. What do you think?