### PR TITLE
Fixed AdjustRoutingKey for Redis broker

### DIFF
--- a/v1/backends/backend.go
+++ b/v1/backends/backend.go
@@ -15,7 +15,7 @@ func New(cnf *config.Config) Backend {
 }
 
 // IsAMQP returns true if the backend is AMQP
-func IsAMQP(backend Interface) bool {
-	_, isAMQPBackend := backend.(*AMQPBackend)
+func IsAMQP(b Interface) bool {
+	_, isAMQPBackend := b.(*AMQPBackend)
 	return isAMQPBackend
 }

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -93,7 +93,7 @@ func (b *AMQPBroker) StopConsuming() {
 // Publish places a new message on the default queue
 func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
-	b.AdjustRoutingKey(signature)
+	AdjustRoutingKey(b, signature)
 
 	msg, err := json.Marshal(signature)
 	if err != nil {

--- a/v1/brokers/interfaces.go
+++ b/v1/brokers/interfaces.go
@@ -1,11 +1,13 @@
 package brokers
 
 import (
+	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
 )
 
 // Interface - a common interface for all brokers
 type Interface interface {
+	GetConfig() *config.Config
 	SetRegisteredTaskNames(names []string)
 	IsTaskRegistered(name string) bool
 	StartConsuming(consumerTag string, concurrency int, p TaskProcessor) (bool, error)

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -134,8 +134,6 @@ func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskPr
 
 // StopConsuming quits the loop
 func (b *RedisBroker) StopConsuming() {
-	b.stopConsuming()
-
 	// Stop the receiving goroutine
 	b.stopReceivingChan <- 1
 	// Waiting for the receiving goroutine to have stopped
@@ -146,6 +144,8 @@ func (b *RedisBroker) StopConsuming() {
 	// Waiting for the delayed tasks goroutine to have stopped
 	b.delayedWG.Wait()
 
+	b.stopConsuming()
+
 	// Waiting for any tasks being processed to finish
 	b.processingWG.Wait()
 }
@@ -153,7 +153,7 @@ func (b *RedisBroker) StopConsuming() {
 // Publish places a new message on the default queue
 func (b *RedisBroker) Publish(signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
-	b.AdjustRoutingKey(signature)
+	AdjustRoutingKey(b, signature)
 
 	msg, err := json.Marshal(signature)
 	if err != nil {

--- a/v1/factories.go
+++ b/v1/factories.go
@@ -18,7 +18,7 @@ func BrokerFactory(cnf *config.Config) (brokers.Interface, error) {
 		return brokers.NewAMQPBroker(cnf), nil
 	}
 
-	if strings.HasPrefix(cnf.ResultBackend, "amqps://") {
+	if strings.HasPrefix(cnf.Broker, "amqps://") {
 		return brokers.NewAMQPBroker(cnf), nil
 	}
 


### PR DESCRIPTION
Current implementation had a bug when AMQP related settings were left in the config file, it would try to use AMQP binding key and hence `AdjustRoutingKey` would set routing key to the binding key even for Redis broker. That should only happen for AMQP broker.