### PR TITLE
Make test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,12 @@ test:
 test-with-coverage:
 	echo "" > coverage.out
 	echo "mode: set" > coverage-all.out
+	TEST_FAILED= ; \
 	for pkg in ${PACKAGES}; do \
-		go test -coverprofile=coverage.out -covermode=set $$pkg; \
+		go test -coverprofile=coverage.out -covermode=set $$pkg || TEST_FAILED=1; \
 		tail -n +2 coverage.out >> coverage-all.out; \
-	done;
+	done; \
+	[ -z "$$TEST_FAILED" ]
 	#go tool cover -html=coverage-all.out
 
 ci:

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,11 @@ golint:
 	done;
 
 test:
+	TEST_FAILED= ; \
 	for pkg in ${PACKAGES}; do \
-		go test $$pkg; \
-	done;
+		go test $$pkg || TEST_FAILED=1; \
+	done; \
+	[ -z "$$TEST_FAILED" ]
 
 test-with-coverage:
 	echo "" > coverage.out


### PR DESCRIPTION
CI isn't reporting the correct results.  Because of the for loop in `make test` and `make test-with-coverage`, an error is only returned if the last suite fails.  This change will cause the build to fail if a test fails in any package.

In the most recent travis builds, there are test failures that don't result in the build failing.

https://travis-ci.org/RichardKnop/machinery/jobs/311917478#L586-L591