### PR TITLE
Fix broker_test

### DIFF
--- a/v1/brokers/broker_test.go
+++ b/v1/brokers/broker_test.go
@@ -33,14 +33,14 @@ func TestAdjustRoutingKey(t *testing.T) {
 			BindingKey:   "binding_key",
 		},
 	})
-	broker.AdjustRoutingKey(s)
+	brokers.AdjustRoutingKey(&broker, s)
 	assert.Equal(t, "routing_key", s.RoutingKey)
 
 	s = &tasks.Signature{RoutingKey: "routing_key"}
 	broker = brokers.New(&config.Config{
 		DefaultQueue: "queue",
 	})
-	broker.AdjustRoutingKey(s)
+	brokers.AdjustRoutingKey(&broker, s)
 	assert.Equal(t, "routing_key", s.RoutingKey)
 
 	// Signatures without routing key
@@ -53,13 +53,13 @@ func TestAdjustRoutingKey(t *testing.T) {
 			BindingKey:   "binding_key",
 		},
 	})
-	broker.AdjustRoutingKey(s)
+	brokers.AdjustRoutingKey(&broker, s)
 	assert.Equal(t, "binding_key", s.RoutingKey)
 
 	s = new(tasks.Signature)
 	broker = brokers.New(&config.Config{
 		DefaultQueue: "queue",
 	})
-	broker.AdjustRoutingKey(s)
+	brokers.AdjustRoutingKey(&broker, s)
 	assert.Equal(t, "queue", s.RoutingKey)
 }

--- a/v1/brokers/broker_test.go
+++ b/v1/brokers/broker_test.go
@@ -23,43 +23,47 @@ func TestAdjustRoutingKey(t *testing.T) {
 		broker brokers.Broker
 	)
 
-	// Signatures with routing key
-
-	s = &tasks.Signature{RoutingKey: "routing_key"}
-	broker = brokers.New(&config.Config{
-		DefaultQueue: "queue",
-		AMQP: &config.AMQPConfig{
-			ExchangeType: "direct",
-			BindingKey:   "binding_key",
-		},
+	t.Run("with routing and binding keys", func(t *testing.T) {
+		s := &tasks.Signature{RoutingKey: "routing_key"}
+		broker := brokers.NewAMQPBroker(&config.Config{
+			DefaultQueue: "queue",
+			AMQP: &config.AMQPConfig{
+				ExchangeType: "direct",
+				BindingKey:   "binding_key",
+			},
+		})
+		brokers.AdjustRoutingKey(broker, s)
+		assert.Equal(t, "routing_key", s.RoutingKey)
 	})
-	brokers.AdjustRoutingKey(&broker, s)
-	assert.Equal(t, "routing_key", s.RoutingKey)
 
-	s = &tasks.Signature{RoutingKey: "routing_key"}
-	broker = brokers.New(&config.Config{
-		DefaultQueue: "queue",
+	t.Run("with routing key", func(t *testing.T) {
+		s = &tasks.Signature{RoutingKey: "routing_key"}
+		broker = brokers.New(&config.Config{
+			DefaultQueue: "queue",
+		})
+		brokers.AdjustRoutingKey(&broker, s)
+		assert.Equal(t, "routing_key", s.RoutingKey)
 	})
-	brokers.AdjustRoutingKey(&broker, s)
-	assert.Equal(t, "routing_key", s.RoutingKey)
 
-	// Signatures without routing key
-
-	s = new(tasks.Signature)
-	broker = brokers.New(&config.Config{
-		DefaultQueue: "queue",
-		AMQP: &config.AMQPConfig{
-			ExchangeType: "direct",
-			BindingKey:   "binding_key",
-		},
+	t.Run("with binding key", func(t *testing.T) {
+		s = new(tasks.Signature)
+		amqpBroker := brokers.NewAMQPBroker(&config.Config{
+			DefaultQueue: "queue",
+			AMQP: &config.AMQPConfig{
+				ExchangeType: "direct",
+				BindingKey:   "binding_key",
+			},
+		})
+		brokers.AdjustRoutingKey(amqpBroker, s)
+		assert.Equal(t, "binding_key", s.RoutingKey)
 	})
-	brokers.AdjustRoutingKey(&broker, s)
-	assert.Equal(t, "binding_key", s.RoutingKey)
 
-	s = new(tasks.Signature)
-	broker = brokers.New(&config.Config{
-		DefaultQueue: "queue",
+	t.Run("with neither routing nor binding key", func(t *testing.T) {
+		s = new(tasks.Signature)
+		broker = brokers.New(&config.Config{
+			DefaultQueue: "queue",
+		})
+		brokers.AdjustRoutingKey(&broker, s)
+		assert.Equal(t, "queue", s.RoutingKey)
 	})
-	brokers.AdjustRoutingKey(&broker, s)
-	assert.Equal(t, "queue", s.RoutingKey)
 }


### PR DESCRIPTION
TestAdjustRoutingKey is failing on master.  I believe this is a problem with the test and not the production code.  

I split the test up into subtests to help keep track of which part is failing.  The section that was failing is in the "with binding key" subtest.  I fixed it by making the broker an AMQPBroker.  That allows it to get past the if statement below.  

This is only a fix if my assumption is correct that only AMQPBrokers should make it past the `IsAMQP` test.

https://github.com/RichardKnop/machinery/blob/f0e7c029c37ba02297b60903237ae9581955b339/v1/brokers/broker.go#L100