### PR TITLE
Adding config option to skip signal handling

### DIFF
--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	ResultsExpireIn int         `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
 	AMQP            *AMQPConfig `yaml:"amqp"`
 	TLSConfig       *tls.Config
+	//NoUnixSignals when set disables signal handling in machinery
+	NoUnixSignals bool `yaml:"no_unix_signals" envconfig:"NO_UNIX_SIGNALS"`
 }
 
 // QueueBindingArgs arguments which are used when binding to the exchange

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -62,33 +62,34 @@ func (worker *Worker) LaunchAsync(errorsChan chan<- error) {
 			}
 		}
 	}()
+	if !cnf.NoUnixSignals {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+		var signalsReceived uint
 
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-	var signalsReceived uint
+		// Goroutine Handle SIGINT and SIGTERM signals
+		go func() {
+			for {
+				select {
+				case s := <-sig:
+					log.WARNING.Printf("Signal received: %v", s)
+					signalsReceived++
 
-	// Goroutine Handle SIGINT and SIGTERM signals
-	go func() {
-		for {
-			select {
-			case s := <-sig:
-				log.WARNING.Printf("Signal received: %v", s)
-				signalsReceived++
-
-				if signalsReceived < 2 {
-					// After first Ctrl+C start quitting the worker gracefully
-					log.WARNING.Print("Waiting for running tasks to finish before shutting down")
-					go func() {
-						worker.Quit()
-						errorsChan <- errors.New("Worker quit gracefully")
-					}()
-				} else {
-					// Abort the program when user hits Ctrl+C second time in a row
-					errorsChan <- errors.New("Worker quit abruptly")
+					if signalsReceived < 2 {
+						// After first Ctrl+C start quitting the worker gracefully
+						log.WARNING.Print("Waiting for running tasks to finish before shutting down")
+						go func() {
+							worker.Quit()
+							errorsChan <- errors.New("Worker quit gracefully")
+						}()
+					} else {
+						// Abort the program when user hits Ctrl+C second time in a row
+						errorsChan <- errors.New("Worker quit abruptly")
+					}
 				}
 			}
-		}
-	}()
+		}()
+	}
 }
 
 // Quit tears down the running worker process


### PR DESCRIPTION
This allows users to define if they want to use machinery's built in signal handling or not, there are cases where users might not want to rely on machinery to do signal handling