### PR TITLE
When config doesn't has AMQP, AMQP still shows up in default config

### DIFF
--- a/v1/config/env.go
+++ b/v1/config/env.go
@@ -40,8 +40,7 @@ func NewFromEnvironment(keepReloading bool) (*Config, error) {
 }
 
 func fromEnvironment() (*Config, error) {
-	loadedCnf := new(Config)
-	cnf := new(Config)
+	loadedCnf, cnf := new(Config), new(Config)
 	*cnf = *defaultCnf
 
 	if err := envconfig.Process("", cnf); err != nil {

--- a/v1/config/env.go
+++ b/v1/config/env.go
@@ -40,11 +40,19 @@ func NewFromEnvironment(keepReloading bool) (*Config, error) {
 }
 
 func fromEnvironment() (*Config, error) {
+	loadedCnf := new(Config)
 	cnf := new(Config)
 	*cnf = *defaultCnf
 
 	if err := envconfig.Process("", cnf); err != nil {
 		return nil, err
+	}
+	if err := envconfig.Process("", loadedCnf); err != nil {
+		return nil, err
+	}
+
+	if loadedCnf.AMQP == nil {
+		cnf.AMQP = nil
 	}
 
 	return cnf, nil

--- a/v1/config/file.go
+++ b/v1/config/file.go
@@ -61,8 +61,7 @@ func ReadFromFile(cnfPath string) ([]byte, error) {
 }
 
 func fromFile(cnfPath string) (*Config, error) {
-	loadedCnf := new(Config)
-	cnf := new(Config)
+	loadedCnf, cnf := new(Config), new(Config)
 	*cnf = *defaultCnf
 
 	data, err := ReadFromFile(cnfPath)

--- a/v1/config/file.go
+++ b/v1/config/file.go
@@ -61,6 +61,7 @@ func ReadFromFile(cnfPath string) ([]byte, error) {
 }
 
 func fromFile(cnfPath string) (*Config, error) {
+	loadedCnf := new(Config)
 	cnf := new(Config)
 	*cnf = *defaultCnf
 
@@ -71,6 +72,12 @@ func fromFile(cnfPath string) (*Config, error) {
 
 	if err := yaml.Unmarshal(data, cnf); err != nil {
 		return nil, fmt.Errorf("Unmarshal YAML error: %s", err)
+	}
+	if err := yaml.Unmarshal(data, loadedCnf); err != nil {
+		return nil, fmt.Errorf("Unmarshal YAML error: %s", err)
+	}
+	if loadedCnf.AMQP == nil {
+		cnf.AMQP = nil
 	}
 
 	return cnf, nil


### PR DESCRIPTION
I found that when other brokers were used, config of AMQP was still in config. So if I don't set ```RoutingKey``` in the signature, then ```AdjustRoutingKey``` will be called, which will go into 
```
if IsAMQP(b) && b.GetConfig().AMQP != nil && b.GetConfig().AMQP.ExchangeType == "direct" {
		// The routing algorithm behind a direct exchange is simple - a message goes
		// to the queues whose binding key exactly matches the routing key of the message.
		s.RoutingKey = b.GetConfig().AMQP.BindingKey
		return
	}
```
So the ```default_queue``` in config file will not be used.