### PR TITLE
SQSConfig options for *sqs.SQS and WaitTimeSeconds

### DIFF
--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -31,8 +31,8 @@ type AWSSQSBroker struct {
 // NewAWSSQSBroker creates new Broker instance
 func NewAWSSQSBroker(cnf *config.Config) Interface {
 	b := &AWSSQSBroker{Broker: New(cnf)}
-	if cnf.SQS != nil {
-		// Use provided *SQS
+	if cnf.SQS != nil && cnf.SQS.Client != nil {
+		// Use provided *SQS client
 		b.service = cnf.SQS.Client
 	} else {
 		// Initialize a session that the SDK will use to load credentials from the shared credentials file, ~/.aws/credentials.

--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -31,14 +31,19 @@ type AWSSQSBroker struct {
 // NewAWSSQSBroker creates new Broker instance
 func NewAWSSQSBroker(cnf *config.Config) Interface {
 	b := &AWSSQSBroker{Broker: New(cnf)}
-	// Initialize a session that the SDK will use to load credentials from the shared credentials file, ~/.aws/credentials.
-	// See details on: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
-	// Also, env AWS_REGION is also required
-	b.sess = session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
-	b.service = sqs.New(b.sess)
-
+	if cnf.SQS != nil {
+		// Use provided *SQS
+		b.service = cnf.SQS.Client
+	} else {
+		// Initialize a session that the SDK will use to load credentials from the shared credentials file, ~/.aws/credentials.
+		// See details on: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
+		// Also, env AWS_REGION is also required
+		b.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+		b.service = sqs.New(b.sess)
+	}
+	
 	return b
 }
 
@@ -233,6 +238,12 @@ func (b *AWSSQSBroker) defaultQueueURL() *string {
 
 // receiveMessage is a method receives a message from specified queue url
 func (b *AWSSQSBroker) receiveMessage(qURL *string) (*sqs.ReceiveMessageOutput, error) {
+	var waitTimeSeconds int
+	if b.cnf.SQS != nil {
+		waitTimeSeconds = b.cnf.SQS.WaitTimeSeconds
+	} else {
+		waitTimeSeconds = 0
+	}
 	result, err := b.service.ReceiveMessage(&sqs.ReceiveMessageInput{
 		AttributeNames: []*string{
 			aws.String(sqs.MessageSystemAttributeNameSentTimestamp),
@@ -243,7 +254,7 @@ func (b *AWSSQSBroker) receiveMessage(qURL *string) (*sqs.ReceiveMessageOutput, 
 		QueueUrl:            qURL,
 		MaxNumberOfMessages: aws.Int64(1),
 		VisibilityTimeout:   aws.Int64(int64(b.cnf.ResultsExpireIn)), // 10 hours
-		WaitTimeSeconds:     aws.Int64(0),
+		WaitTimeSeconds:     aws.Int64(int64(waitTimeSeconds)),
 	})
 	if err != nil {
 		return nil, err

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	ResultBackend   string      `yaml:"result_backend" envconfig:"RESULT_BACKEND"`
 	ResultsExpireIn int         `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
 	AMQP            *AMQPConfig `yaml:"amqp"`
+	SQS             *SQSConfig  `yaml:"sqs"`
 	TLSConfig       *tls.Config
 }
 
@@ -45,6 +46,12 @@ type AMQPConfig struct {
 	QueueBindingArgs QueueBindingArgs `yaml:"queue_binding_args" envconfig:"AMQP_QUEUE_BINDING_ARGS"`
 	BindingKey       string           `yaml:"binding_key" envconfig:"AMQP_BINDING_KEY"`
 	PrefetchCount    int              `yaml:"prefetch_count" envconfig:"AMQP_PREFETCH_COUNT"`
+}
+
+// SQSConfig wraps SQS related configuration
+type SQSConfig struct {
+	Client          *sqs.SQS
+	WaitTimeSeconds int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
 }
 
 // Decode from yaml to map (any field whose type or pointer-to-type implements


### PR DESCRIPTION
Updated aws_sqs broker & config.Config to allow passing a manually created *SQS client, and the ReceiveMessageInput WaitTimeSeconds value. 