### PR TITLE
Fix NewPool and Rewrite ParseRedisURL

### DIFF
--- a/v1/common/redis.go
+++ b/v1/common/redis.go
@@ -22,11 +22,11 @@ func (rc *RedisConnector) NewPool(socketPath, host, password string, db int) *re
 
 			if db != 0 {
 				_, err = c.Do("SELECT", db)
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			if err != nil {
-				return nil, err
-			}
 			return c, err
 		},
 		// PINGs connections that have been idle more than 10 seconds

--- a/v1/factories.go
+++ b/v1/factories.go
@@ -3,6 +3,7 @@ package machinery
 import (
 	"errors"
 	"fmt"
+	neturl "net/url"
 	"strconv"
 	"strings"
 
@@ -115,36 +116,32 @@ func BackendFactory(cnf *config.Config) (backends.Interface, error) {
 func ParseRedisURL(url string) (host, password string, db int, err error) {
 	// redis://pwd@host/db
 
-	parts := strings.Split(url, "redis://")
-	if parts[0] != "" {
+	var u *neturl.URL
+	u, err = neturl.Parse(url)
+	if err != nil {
+		return
+	}
+	if u.Scheme != "redis" {
 		err = errors.New("No redis scheme found")
 		return
 	}
-	if len(parts) != 2 {
-		err = fmt.Errorf("Redis connection string should be in format redis://password@host:port/db, instead got %s", url)
-		return
+
+	if u.User != nil {
+		password = u.User.String()
 	}
-	parts = strings.Split(parts[1], "@")
-	var hostAndDB string
-	if len(parts) == 2 {
-		//[pwd, host/db]
-		password = parts[0]
-		hostAndDB = parts[1]
-	} else {
-		hostAndDB = parts[0]
-	}
-	parts = strings.Split(hostAndDB, "/")
+
+	host = u.Host
+
+	parts := strings.Split(u.Path, "/")
 	if len(parts) == 1 {
-		//[host]
-		host, db = parts[0], 0 //default redis db
+		db = 0 //default redis db
 	} else {
-		//[host, db]
-		host = parts[0]
 		db, err = strconv.Atoi(parts[1])
 		if err != nil {
 			db, err = 0, nil //ignore err here
 		}
 	}
+
 	return
 }
 

--- a/v1/factories_test.go
+++ b/v1/factories_test.go
@@ -265,8 +265,12 @@ func TestParseRedisURL(t *testing.T) {
 	assert.Error(t, err, "invalid redis scheme")
 
 	url = "redis:/"
-	_, _, _, err = machinery.ParseRedisURL(url)
-	assert.Error(t, err, "invalid redis url scheme")
+	host, pwd, db, err = machinery.ParseRedisURL(url)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "", host)
+		assert.Equal(t, "", pwd)
+		assert.Equal(t, 0, db)
+	}
 
 	url = "redis://127.0.0.1:5672"
 	host, pwd, db, err = machinery.ParseRedisURL(url)
@@ -277,7 +281,7 @@ func TestParseRedisURL(t *testing.T) {
 	}
 
 	url = "redis://pwd@127.0.0.1:5672"
-	host, pwd, db, _ = machinery.ParseRedisURL(url)
+	host, pwd, db, err = machinery.ParseRedisURL(url)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "127.0.0.1:5672", host)
 		assert.Equal(t, "pwd", pwd)


### PR DESCRIPTION
Fix `NewPool` Logic and Rewrite `ParseRedisURL` using `url.Parse`(It's probably more robust to just use url.Parse and extract all the info from the URL)

Signed-off-by: duyanghao <1294057873@qq.com>