### PR TITLE
ISSUE-232: prevent multiple chord triggers w/ concurrent workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage*
 _vendor-*
 .idea/*
-
+.env
+.DS_Store

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,13 +19,15 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.test
-    env_file:
-        - .env
     environment:
       AMQP_URL: 'amqp://guest:guest@rabbitmq:5672/'
       REDIS_URL: 'redis:6379'
       MEMCACHE_URL: 'memcached:11211'
       MONGODB_URL: 'mongo:27017'
+      SQS_URL: ${SQS_URL}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
 
   rabbitmq:
     container_name: machinery_sut_rabbitmq

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.test
+    env_file:
+        - .env
     environment:
       AMQP_URL: 'amqp://guest:guest@rabbitmq:5672/'
       REDIS_URL: 'redis:6379'
@@ -51,3 +53,5 @@ services:
     image: mongo
     logging:
       driver: none
+    ports:
+      - "27017:27017"

--- a/integration-tests/sqs_mongodb_test.go
+++ b/integration-tests/sqs_mongodb_test.go
@@ -12,12 +12,13 @@ func TestSQSMongodb(t *testing.T) {
 	sqsURL := os.Getenv("SQS_URL")
 	mongodbURL := os.Getenv("MONGODB_URL")
 	if sqsURL == "" || mongodbURL == "" {
+		t.Error("shhhiiiit", sqsURL)
 		return
 	}
 
 	// AMQP broker, MongoDB result backend
 	server := testSetup(&config.Config{
-		Broker:        "https://sqs.us-east-2.amazonaws.com/155825796015",
+		Broker:        sqsURL,
 		DefaultQueue:  "test_queue",
 		ResultBackend: fmt.Sprintf("mongodb://%v", mongodbURL),
 	})

--- a/integration-tests/sqs_mongodb_test.go
+++ b/integration-tests/sqs_mongodb_test.go
@@ -1,0 +1,28 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/RichardKnop/machinery/v1/config"
+)
+
+func TestSQSMongodb(t *testing.T) {
+	sqsURL := os.Getenv("SQS_URL")
+	mongodbURL := os.Getenv("MONGODB_URL")
+	if sqsURL == "" || mongodbURL == "" {
+		return
+	}
+
+	// AMQP broker, MongoDB result backend
+	server := testSetup(&config.Config{
+		Broker:        "https://sqs.us-east-2.amazonaws.com/155825796015",
+		DefaultQueue:  "test_queue",
+		ResultBackend: fmt.Sprintf("mongodb://%v", mongodbURL),
+	})
+	worker := server.NewWorker("test_worker", 0)
+	go worker.Launch()
+	testAll(server, t)
+	worker.Quit()
+}

--- a/integration-tests/sqs_mongodb_test.go
+++ b/integration-tests/sqs_mongodb_test.go
@@ -12,7 +12,6 @@ func TestSQSMongodb(t *testing.T) {
 	sqsURL := os.Getenv("SQS_URL")
 	mongodbURL := os.Getenv("MONGODB_URL")
 	if sqsURL == "" || mongodbURL == "" {
-		t.Error("shhhiiiit", sqsURL)
 		return
 	}
 

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -101,6 +101,11 @@ func (b *MongodbBackend) TriggerChord(groupUUID string) (bool, error) {
 		return false, err
 	}
 	defer b.unlockGroupMeta(groupUUID)
+	
+	// Check if chord has been triggered after unlock acquired, return false (should not trigger again)
+	if groupMeta.ChordTriggered {
+		return false, nil
+	}
 
 	// Update the group meta data
 	update := bson.M{"$set": bson.M{"chord_triggered": true}}

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -207,9 +207,8 @@ func (b *MongodbBackend) lockGroupMeta(groupUUID string) error {
 		"lock": false,
 	}
 	change := mgo.Change{
-		Update:    bson.M{
-			"$set": 
-			bson.M{
+		Update: bson.M{
+			"$set": bson.M{
 				"lock": true,
 			},
 		},

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -95,17 +95,17 @@ func (b *MongodbBackend) TriggerChord(groupUUID string) (bool, error) {
 		log.WARNING.Print("Group meta locked, waiting")
 		<-time.After(time.Millisecond * 5)
 	}
+	
+	// Check if chord has been triggered after unlock acquired, return false (should not trigger again)
+	if groupMeta.ChordTriggered {
+		return false, nil
+	}
 
 	// Acquire lock
 	if err = b.lockGroupMeta(groupUUID); err != nil {
 		return false, err
 	}
 	defer b.unlockGroupMeta(groupUUID)
-	
-	// Check if chord has been triggered after unlock acquired, return false (should not trigger again)
-	if groupMeta.ChordTriggered {
-		return false, nil
-	}
 
 	// Update the group meta data
 	update := bson.M{"$set": bson.M{"chord_triggered": true}}

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -210,9 +210,9 @@ func (b *MongodbBackend) lockGroupMeta(groupUUID string) error {
 		Update:    bson.M{
 			"$set": 
 			bson.M{
-				"lock": true
-				},
+				"lock": true,
 			},
+		},
 		ReturnNew: false,
 	}
 	_, err := b.groupMetasCollection.

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -77,43 +77,28 @@ func (b *MongodbBackend) TriggerChord(groupUUID string) (bool, error) {
 	if err := b.connect(); err != nil {
 		return false, err
 	}
-
-	// Get the group meta data
-	groupMeta, err := b.getGroupMeta(groupUUID)
+	query := bson.M{
+		"_id":             groupUUID,
+		"chord_triggered": false,
+	}
+	change := mgo.Change{
+		Update: bson.M{
+			"$set": bson.M{
+				"chord_triggered": true,
+			},
+		},
+		ReturnNew: false,
+	}
+	_, err := b.groupMetasCollection.
+		Find(query).
+		Apply(change, nil)
 	if err != nil {
+		if err == mgo.ErrNotFound {
+			log.WARNING.Printf("Chord already triggered for group %s", groupUUID)
+			return false, nil
+		}
 		return false, err
 	}
-
-	// Chord has already been triggered, return false (should not trigger again)
-	if groupMeta.ChordTriggered {
-		return false, nil
-	}
-
-	// If group meta is locked, wait until it's unlocked
-	for groupMeta.Lock {
-		groupMeta, _ = b.getGroupMeta(groupUUID)
-		log.WARNING.Print("Group meta locked, waiting")
-		<-time.After(time.Millisecond * 5)
-	}
-	
-	// Check if chord has been triggered after unlock acquired, return false (should not trigger again)
-	if groupMeta.ChordTriggered {
-		return false, nil
-	}
-
-	// Acquire lock
-	if err = b.lockGroupMeta(groupUUID); err != nil {
-		return false, err
-	}
-	defer b.unlockGroupMeta(groupUUID)
-
-	// Update the group meta data
-	update := bson.M{"$set": bson.M{"chord_triggered": true}}
-	_, err = b.groupMetasCollection.UpsertId(groupUUID, update)
-	if err != nil {
-		return false, err
-	}
-
 	return true, nil
 }
 
@@ -217,8 +202,22 @@ func (b *MongodbBackend) PurgeGroupMeta(groupUUID string) error {
 
 // lockGroupMeta acquires lock on groupUUID document
 func (b *MongodbBackend) lockGroupMeta(groupUUID string) error {
-	update := bson.M{"$set": bson.M{"lock": true}}
-	_, err := b.groupMetasCollection.UpsertId(groupUUID, update)
+	query := bson.M{
+		"_id":  groupUUID,
+		"lock": false,
+	}
+	change := mgo.Change{
+		Update:    bson.M{
+			"$set": 
+			bson.M{
+				"lock": true
+				},
+			},
+		ReturnNew: false,
+	}
+	_, err := b.groupMetasCollection.
+		Find(query).
+		Apply(change, nil)
 	return err
 }
 

--- a/v1/backends/mongodb.go
+++ b/v1/backends/mongodb.go
@@ -89,20 +89,15 @@ func (b *MongodbBackend) TriggerChord(groupUUID string) (bool, error) {
 		},
 		ReturnNew: false,
 	}
-	var groupMeta tasks.GroupMeta
 	_, err := b.groupMetasCollection.
 		Find(query).
-		Apply(change, &groupMeta)
+		Apply(change, nil)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			log.WARNING.Printf("Chord already triggered for group %s", groupUUID)
 			return false, nil
 		}
 		return false, err
-	}
-	if groupMeta.ChordTriggered {
-		log.WARNING.Printf("Chord already triggered for group %s", groupUUID)
-		return false, nil
 	}
 	return true, nil
 }

--- a/v1/tasks/state.go
+++ b/v1/tasks/state.go
@@ -29,7 +29,7 @@ type TaskState struct {
 type GroupMeta struct {
 	GroupUUID      string   `bson:"_id"`
 	TaskUUIDs      []string `bson:"task_uuids"`
-	ChordTriggered bool     `bson:"chord_trigerred"`
+	ChordTriggered bool     `bson:"chord_triggered"`
 	Lock           bool     `bson:"lock"`
 }
 


### PR DESCRIPTION
- use findAndModify where lock is false to avoid update race conditions & simplify lock check
- use findAndModify in lockGroupMeta
