### PR TITLE
Added tasks.ErrRetryTaskLater

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,12 @@ You can set a number of retry attempts before declaring task as failed. Fibonacc
 signature.RetryCount = 3
 ```
 
+Alternatively, you can return `tasks.ErrRetryTaskLater` from your task and specify duration after which the task should be retried, e.g.:
+
+```go
+return tasks.NewErrRetryTaskLater("some error", 4 * time.Hour)
+```
+
 #### Get Pending Tasks
 
 Tasks currently waiting in the queue to be consumed by workers can be inspected, e.g.:

--- a/v1/brokers/errors.go
+++ b/v1/brokers/errors.go
@@ -15,7 +15,7 @@ func (e ErrCouldNotUnmarshaTaskSignature) Error() string {
 	return fmt.Sprintf("Could not unmarshal '%s' into a task signature: %v", e.msg, e.reason)
 }
 
-// NewErrCouldNotUnmarshaTaskSignature returns new NewErrCouldNotUnmarshaTaskSignature instance
+// NewErrCouldNotUnmarshaTaskSignature returns new ErrCouldNotUnmarshaTaskSignature instance
 func NewErrCouldNotUnmarshaTaskSignature(msg []byte, err error) ErrCouldNotUnmarshaTaskSignature {
 	return ErrCouldNotUnmarshaTaskSignature{msg: msg, reason: err.Error()}
 }

--- a/v1/tasks/errors.go
+++ b/v1/tasks/errors.go
@@ -1,0 +1,32 @@
+package tasks
+
+import (
+	"fmt"
+	"time"
+)
+
+// ErrRetryTaskLater ...
+type ErrRetryTaskLater struct {
+	name, msg string
+	retryIn   time.Duration
+}
+
+// RetryIn returns time.Duration from now when task should be retried
+func (e ErrRetryTaskLater) RetryIn() time.Duration {
+	return e.retryIn
+}
+
+// Error implements the error interface
+func (e ErrRetryTaskLater) Error() string {
+	return fmt.Sprintf("Task error: %s Will retry in: %s", e.msg, e.retryIn)
+}
+
+// NewErrRetryTaskLater returns new ErrRetryTaskLater instance
+func NewErrRetryTaskLater(msg string, retryIn time.Duration) ErrRetryTaskLater {
+	return ErrRetryTaskLater{msg: msg, retryIn: retryIn}
+}
+
+// Retriable is interface that retriable errors should implement
+type Retriable interface {
+	RetryIn() time.Duration
+}

--- a/v1/tasks/task.go
+++ b/v1/tasks/task.go
@@ -89,11 +89,20 @@ func (t *Task) Call() (taskResults []*TaskResult, err error) {
 	// is not the case, return error message, otherwise propagate the task error
 	// to the caller
 	if !lastResult.IsNil() {
+		// If the result implements Retriable interface, return instance of Retriable
+		retriableErrorInterface := reflect.TypeOf((*Retriable)(nil)).Elem()
+		if lastResult.Type().Implements(retriableErrorInterface) {
+			return nil, lastResult.Interface().(ErrRetryTaskLater)
+		}
+
+		// Otherwise, check that the result implements the standard error interface,
+		// if not, return ErrLastReturnValueMustBeError error
 		errorInterface := reflect.TypeOf((*error)(nil)).Elem()
 		if !lastResult.Type().Implements(errorInterface) {
 			return nil, ErrLastReturnValueMustBeError
 		}
 
+		// Return the standard error
 		return nil, lastResult.Interface().(error)
 	}
 

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -132,7 +132,15 @@ func (worker *Worker) Process(signature *tasks.Signature) error {
 	// Call the task
 	results, err := task.Call()
 	if err != nil {
-		// Let's retry the task
+		// If a tasks.ErrRetryTaskLater was returned from the task,
+		// retry the task after specified duration
+		retriableErr, ok := interface{}(err).(tasks.ErrRetryTaskLater)
+		if ok {
+			return worker.retryTaskIn(signature, retriableErr.RetryIn())
+		}
+
+		// Otherwise, execute default retry logic based on signature.RetryCount
+		// and signature.RetryTimeout values
 		if signature.RetryCount > 0 {
 			return worker.taskRetry(signature)
 		}
@@ -160,7 +168,25 @@ func (worker *Worker) taskRetry(signature *tasks.Signature) error {
 	eta := time.Now().UTC().Add(time.Second * time.Duration(signature.RetryTimeout))
 	signature.ETA = &eta
 
-	log.WARNING.Printf("Task %s failed. Going to retry in %ds.", signature.UUID, signature.RetryTimeout)
+	log.WARNING.Printf("Task %s failed. Going to retry in %d seconds.", signature.UUID, signature.RetryTimeout)
+
+	// Send the task back to the queue
+	_, err := worker.server.SendTask(signature)
+	return err
+}
+
+// taskRetryIn republishes the task to the queue with ETA of now + retryIn.Seconds()
+func (worker *Worker) retryTaskIn(signature *tasks.Signature, retryIn time.Duration) error {
+	// Update task state to RETRY
+	if err := worker.server.GetBackend().SetStateRetry(signature); err != nil {
+		return fmt.Errorf("Set state retry error: %s", err)
+	}
+
+	// Delay task by retryIn duration
+	eta := time.Now().UTC().Add(retryIn)
+	signature.ETA = &eta
+
+	log.WARNING.Printf("Task %s failed. Going to retry in %.0f seconds.", signature.UUID, retryIn.Seconds())
 
 	// Send the task back to the queue
 	_, err := worker.server.SendTask(signature)


### PR DESCRIPTION
You can now return `tasks.ErrRetryTaskLater` from your task and specify duration after which the task should be retried, e.g.:

```go
return tasks.NewErrRetryTaskLater("some error", 4 * time.Hour)
```

This is useful so you can implement a custom retry logic and not rely on the default behaviour when task is retried using a Fibonacci sequence as a backoff function.