### PR TITLE
Use json.Number when unmarshaling JSON

### DIFF
--- a/integration-tests/eager_eager_test.go
+++ b/integration-tests/eager_eager_test.go
@@ -85,15 +85,15 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 		s.True(asyncResult.GetState().IsSuccess())
 
 		results, err := asyncResult.Get(time.Duration(time.Millisecond * 5))
-		s.Nil(err)
+		if s.NoError(err) {
+			if len(results) != 1 {
+				s.T().Errorf("Number of results returned = %d. Wanted %d", len(results), 1)
+			}
 
-		if len(results) != 1 {
-			s.T().Errorf("Number of results returned = %d. Wanted %d", len(results), 1)
-		}
-
-		s.Equal(reflect.Float64, results[0].Kind())
-		if results[0].Kind() == reflect.Float64 {
-			s.Equal(200.0, results[0].Float())
+			s.Equal(reflect.Float64, results[0].Kind())
+			if results[0].Kind() == reflect.Float64 {
+				s.Equal(200.0, results[0].Float())
+			}
 		}
 	}
 
@@ -116,15 +116,15 @@ func (s *EagerIntegrationTestSuite) TestSuccessResult() {
 		s.True(asyncResult.GetState().IsSuccess())
 
 		results, err := asyncResult.Get(time.Duration(time.Millisecond * 5))
-		s.Nil(err)
+		if s.NoError(err) {
+			if len(results) != 1 {
+				s.T().Errorf("Number of results returned = %d. Wanted %d", len(results), 1)
+			}
 
-		if len(results) != 1 {
-			s.T().Errorf("Number of results returned = %d. Wanted %d", len(results), 1)
-		}
-
-		s.Equal(reflect.Int64, results[0].Kind())
-		if results[0].Kind() == reflect.Int64 {
-			s.Equal(int64(200), results[0].Int())
+			s.Equal(reflect.Int64, results[0].Kind())
+			if results[0].Kind() == reflect.Int64 {
+				s.Equal(int64(200), results[0].Int())
+			}
 		}
 	}
 }

--- a/v1/backends/eager.go
+++ b/v1/backends/eager.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -157,7 +158,9 @@ func (b *EagerBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	}
 
 	state := new(tasks.TaskState)
-	if err := json.Unmarshal(tasktStateBytes, state); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(tasktStateBytes))
+	decoder.UseNumber()
+	if err := decoder.Decode(state); err != nil {
 		return nil, fmt.Errorf("Failed to unmarshal task state %v", b)
 	}
 

--- a/v1/backends/eager_test.go
+++ b/v1/backends/eager_test.go
@@ -1,6 +1,7 @@
 package backends_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/RichardKnop/machinery/v1/backends"
@@ -231,7 +232,7 @@ func (s *EagerBackendTestSuite) TestSetStateSuccess() {
 		taskResults := []*tasks.TaskResult{
 			{
 				Type:  "float64",
-				Value: float64(300.0),
+				Value: json.Number("300.0"),
 			},
 		}
 		s.backend.SetStateSuccess(t, taskResults)

--- a/v1/backends/memcache.go
+++ b/v1/backends/memcache.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 
@@ -165,7 +166,9 @@ func (b *MemcacheBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	}
 
 	state := new(tasks.TaskState)
-	if err := json.Unmarshal(item.Value, state); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(item.Value))
+	decoder.UseNumber()
+	if err := decoder.Decode(state); err != nil {
 		return nil, err
 	}
 
@@ -234,7 +237,9 @@ func (b *MemcacheBackend) getGroupMeta(groupUUID string) (*tasks.GroupMeta, erro
 	}
 
 	groupMeta := new(tasks.GroupMeta)
-	if err := json.Unmarshal(item.Value, groupMeta); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(item.Value))
+	decoder.UseNumber()
+	if err := decoder.Decode(groupMeta); err != nil {
 		return nil, err
 	}
 
@@ -252,7 +257,9 @@ func (b *MemcacheBackend) getStates(taskUUIDs ...string) ([]*tasks.TaskState, er
 		}
 
 		state := new(tasks.TaskState)
-		if err := json.Unmarshal(item.Value, state); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(item.Value))
+		decoder.UseNumber()
+		if err := decoder.Decode(state); err != nil {
 			return nil, err
 		}
 

--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -180,7 +181,9 @@ func (b *RedisBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	}
 
 	state := new(tasks.TaskState)
-	if err := json.Unmarshal(item, state); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(item))
+	decoder.UseNumber()
+	if err := decoder.Decode(state); err != nil {
 		return nil, err
 	}
 
@@ -224,7 +227,9 @@ func (b *RedisBackend) getGroupMeta(groupUUID string) (*tasks.GroupMeta, error) 
 	}
 
 	groupMeta := new(tasks.GroupMeta)
-	if err := json.Unmarshal(item, groupMeta); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(item))
+	decoder.UseNumber()
+	if err := decoder.Decode(groupMeta); err != nil {
 		return nil, err
 	}
 
@@ -250,13 +255,15 @@ func (b *RedisBackend) getStates(taskUUIDs ...string) ([]*tasks.TaskState, error
 	}
 
 	for i, value := range reply {
-		bytes, ok := value.([]byte)
+		stateBytes, ok := value.([]byte)
 		if !ok {
 			return taskStates, fmt.Errorf("Expected byte array, instead got: %v", value)
 		}
 
 		taskState := new(tasks.TaskState)
-		if err := json.Unmarshal(bytes, taskState); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(stateBytes))
+		decoder.UseNumber()
+		if err := decoder.Decode(taskState); err != nil {
 			log.ERROR.Print(err)
 			return taskStates, err
 		}

--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -1,6 +1,7 @@
 package brokers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -193,7 +194,9 @@ func (b *AWSSQSBroker) consumeOne(delivery *sqs.ReceiveMessageOutput, taskProces
 		return errors.New("received empty message, the delivery is " + delivery.GoString())
 	}
 	msg := delivery.Messages[0].Body
-	if err := json.Unmarshal([]byte(*msg), sig); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader([]byte(*msg)))
+	decoder.UseNumber()
+	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
 		return err
 	}

--- a/v1/brokers/eager.go
+++ b/v1/brokers/eager.go
@@ -1,6 +1,7 @@
 package brokers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,8 +49,9 @@ func (eagerBroker *EagerBroker) Publish(task *tasks.Signature) error {
 	}
 
 	signature := new(tasks.Signature)
-	err = json.Unmarshal(message, &signature)
-	if err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(message))
+	decoder.UseNumber()
+	if err := decoder.Decode(signature); err != nil {
 		return fmt.Errorf("JSON unmarshal error: %s", err)
 	}
 

--- a/v1/tasks/reflect_test.go
+++ b/v1/tasks/reflect_test.go
@@ -1,6 +1,7 @@
 package tasks_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
@@ -10,149 +11,163 @@ func TestReflectValue(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name     string
-		value    interface{}
-		expected string
+		name          string
+		value         interface{}
+		expectedType  string
+		expectedValue interface{}
 	}{
 		{
-			name:     "bool",
-			value:    false,
-			expected: "bool",
+			name:         "bool",
+			value:        false,
+			expectedType: "bool",
 		},
 		{
-			name:     "int",
-			value:    float64(1),
-			expected: "int",
+			name:          "int",
+			value:         json.Number("123"),
+			expectedType:  "int",
+			expectedValue: int(123),
 		},
 		{
-			name:     "int8",
-			value:    float64(1),
-			expected: "int8",
+			name:          "int8",
+			value:         json.Number("123"),
+			expectedType:  "int8",
+			expectedValue: int8(123),
 		},
 		{
-			name:     "int16",
-			value:    float64(1),
-			expected: "int16",
+			name:          "int16",
+			value:         json.Number("123"),
+			expectedType:  "int16",
+			expectedValue: int16(123),
 		},
 		{
-			name:     "int32",
-			value:    float64(1),
-			expected: "int32",
+			name:          "int32",
+			value:         json.Number("123"),
+			expectedType:  "int32",
+			expectedValue: int32(123),
 		},
 		{
-			name:     "int64",
-			value:    float64(1),
-			expected: "int64",
+			name:          "int64",
+			value:         json.Number("185135722552891243"),
+			expectedType:  "int64",
+			expectedValue: int64(185135722552891243),
 		},
 		{
-			name:     "uint",
-			value:    float64(1),
-			expected: "uint",
+			name:          "uint",
+			value:         json.Number("123"),
+			expectedType:  "uint",
+			expectedValue: uint(123),
 		},
 		{
-			name:     "uint8",
-			value:    float64(1),
-			expected: "uint8",
+			name:          "uint8",
+			value:         json.Number("123"),
+			expectedType:  "uint8",
+			expectedValue: uint8(123),
 		},
 		{
-			name:     "uint16",
-			value:    float64(1),
-			expected: "uint16",
+			name:          "uint16",
+			value:         json.Number("123"),
+			expectedType:  "uint16",
+			expectedValue: uint16(123),
 		},
 		{
-			name:     "uint32",
-			value:    float64(1),
-			expected: "uint32",
+			name:          "uint32",
+			value:         json.Number("123"),
+			expectedType:  "uint32",
+			expectedValue: uint32(123),
 		},
 		{
-			name:     "uint64",
-			value:    float64(1),
-			expected: "uint64",
+			name:          "uint64",
+			value:         json.Number("185135722552891243"),
+			expectedType:  "uint64",
+			expectedValue: uint64(185135722552891243),
 		},
 		{
-			name:     "float32",
-			value:    float64(0.5),
-			expected: "float32",
+			name:          "float32",
+			value:         json.Number("0.5"),
+			expectedType:  "float32",
+			expectedValue: float32(0.5),
 		},
 		{
-			name:     "float64",
-			value:    float64(0.5),
-			expected: "float64",
+			name:          "float64",
+			value:         json.Number("0.5"),
+			expectedType:  "float64",
+			expectedValue: float64(0.5),
 		},
 		{
-			name:     "string",
-			value:    "123",
-			expected: "string",
+			name:          "string",
+			value:         "123",
+			expectedType:  "string",
+			expectedValue: "123",
 		},
 		{
-			name:     "[]bool",
-			value:    []interface{}{false, true},
-			expected: "[]bool",
+			name:         "[]bool",
+			value:        []interface{}{false, true},
+			expectedType: "[]bool",
 		},
 		{
-			name:     "[]int",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]int",
+			name:         "[]int",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]int",
 		},
 		{
-			name:     "[]int8",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]int8",
+			name:         "[]int8",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]int8",
 		},
 		{
-			name:     "[]int16",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]int16",
+			name:         "[]int16",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]int16",
 		},
 		{
-			name:     "[]int32",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]int32",
+			name:         "[]int32",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]int32",
 		},
 		{
-			name:     "[]int64",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]int64",
+			name:         "[]int64",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]int64",
 		},
 		{
-			name:     "[]uint",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]uint",
+			name:         "[]uint",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]uint",
 		},
 		{
-			name:     "[]uint8",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]uint8",
+			name:         "[]uint8",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]uint8",
 		},
 		{
-			name:     "[]uint16",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]uint16",
+			name:         "[]uint16",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]uint16",
 		},
 		{
-			name:     "[]uint32",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]uint32",
+			name:         "[]uint32",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]uint32",
 		},
 		{
-			name:     "[]uint64",
-			value:    []interface{}{float64(1), float64(2)},
-			expected: "[]uint64",
+			name:         "[]uint64",
+			value:        []interface{}{json.Number("123"), json.Number("234")},
+			expectedType: "[]uint64",
 		},
 		{
-			name:     "[]float32",
-			value:    []interface{}{float64(0.5), float64(1)},
-			expected: "[]float32",
+			name:         "[]float32",
+			value:        []interface{}{json.Number("0.5"), json.Number("1.28")},
+			expectedType: "[]float32",
 		},
 		{
-			name:     "[]float64",
-			value:    []interface{}{float64(1), float64(0.5)},
-			expected: "[]float64",
+			name:         "[]float64",
+			value:        []interface{}{json.Number("0.5"), json.Number("1.28")},
+			expectedType: "[]float64",
 		},
 		{
-			name:     "[]string",
-			value:    []interface{}{"foo", "bar"},
-			expected: "[]string",
+			name:         "[]string",
+			value:        []interface{}{"foo", "bar"},
+			expectedType: "[]string",
 		},
 	}
 
@@ -161,8 +176,13 @@ func TestReflectValue(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if value.Type().String() != testCase.expected {
-			t.Errorf("type is %v, want %s", value.Type().String(), testCase.expected)
+		if value.Type().String() != testCase.expectedType {
+			t.Errorf("type is %v, want %s", value.Type().String(), testCase.expectedType)
+		}
+		if testCase.expectedValue != nil {
+			if value.Interface() != testCase.expectedValue {
+				t.Errorf("value is %v, want %v", value.Interface(), testCase.expectedValue)
+			}
 		}
 	}
 }

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -9,8 +9,8 @@ import (
 
 // Arg represents a single argument passed to invocation fo a task
 type Arg struct {
-	Type  string
-	Value interface{}
+	Type  string      `bson:"type"`
+	Value interface{} `bson:"value"`
 }
 
 // Headers represents the headers which should be used to direct the task


### PR DESCRIPTION
This is in order to not lose any precision when dealing with big integers.

JSON/JavaScript only support floating point numbers so any time we marshal a signature to JSON message to send it over message queue to a worker, it needs to be decoded on the other side.

When decoding into `interface{}`, this would cause problems with large integer and unsigned integers, namely losing of precision. This problem is solved by using https://golang.org/pkg/encoding/json/#Decoder.UseNumber