### PR TITLE
fix(example): make split example use traced function

### DIFF
--- a/example/machinery.go
+++ b/example/machinery.go
@@ -323,7 +323,7 @@ func send() error {
 	}
 	log.INFO.Printf("concat([\"foo\", \"bar\"]) = %v\n", tasks.HumanReadableResults(results))
 
-	asyncResult, err = server.SendTask(&splitTask)
+	asyncResult, err = server.SendTaskWithContext(ctx, &splitTask)
 	if err != nil {
 		return fmt.Errorf("Could not send task: %s", err.Error())
 	}


### PR DESCRIPTION
Otherwise you'll get a dangling trace that is not associated with
the rest of the spans in the example.