### PR TITLE
fix sqs task process deletion

### DIFF
--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -207,11 +207,12 @@ func (b *AWSSQSBroker) consumeOne(delivery *sqs.ReceiveMessageOutput, taskProces
 	}
 
 	err := taskProcessor.Process(sig)
-	if err == nil {
-		// Delete message after successfully consuming and processing the message
-		if err := b.deleteOne(delivery); err != nil {
-			log.ERROR.Printf("error when deleting the delivery. the delivery is %v", delivery)
-		}
+	if err != nil {
+		return err
+	}
+	// Delete message after successfully consuming and processing the message
+	if err = b.deleteOne(delivery); err != nil {
+		log.ERROR.Printf("error when deleting the delivery. the delivery is %v", delivery)
 	}
 	return err
 }

--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -207,7 +207,7 @@ func (b *AWSSQSBroker) consumeOne(delivery *sqs.ReceiveMessageOutput, taskProces
 	}
 
 	err := taskProcessor.Process(sig)
-	if err != nil {
+	if err == nil {
 		// Delete message after successfully consuming and processing the message
 		if err := b.deleteOne(delivery); err != nil {
 			log.ERROR.Printf("error when deleting the delivery. the delivery is %v", delivery)


### PR DESCRIPTION
fixing a bug in the err handling of processed tasks.

current behavior:
a task is attempted deletion when process returns an error

expected behavior: 
a task should be attempt deletion when process does not return an error