### PR TITLE
sqs visibility-timeout config option, readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,17 @@ var sqsClient = sqs.New(session.Must(session.NewSession(&aws.Config{
     Timeout: time.Second * 120,
   },
 })))
+var visibilityTimeout = 30
 var cnf = &config.Config{
   Broker:          "YOUR_SQS_URL"
   DefaultQueue:    "machinery_tasks",
+  ResultBackend:   "YOUR_BACKEND_URL",
   SQS: &config.SQSConfig{
     Client: sqsClient,
+    // if VisibilityTimeout is nil default to the overall visibility timeout setting for the queue
+    // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+    VisibilityTimeout: &visibilityTimeout,
+    WaitTimeSeconds: 20,
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ var sqsClient = sqs.New(session.Must(session.NewSession(&aws.Config{
     Timeout: time.Second * 120,
   },
 })))
-var visibilityTimeout = 30
+var visibilityTimeout = 20
 var cnf = &config.Config{
   Broker:          "YOUR_SQS_URL"
   DefaultQueue:    "machinery_tasks",
@@ -151,7 +151,7 @@ var cnf = &config.Config{
     // if VisibilityTimeout is nil default to the overall visibility timeout setting for the queue
     // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
     VisibilityTimeout: &visibilityTimeout,
-    WaitTimeSeconds: 20,
+    WaitTimeSeconds: 30,
   },
 }
 ```

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -67,6 +67,9 @@ type DynamoDBConfig struct {
 type SQSConfig struct {
 	Client          *sqs.SQS
 	WaitTimeSeconds int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
+	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+	// visiblity timeout should default to nil to use the overall visibility timeout for the queue
+	VisibilityTimeout *int `yaml:"receive_visibility_timeout" envconfig:"SQS_VISIBILITY_TIMEOUT"`
 }
 
 // Decode from yaml to map (any field whose type or pointer-to-type implements


### PR DESCRIPTION
we discovered that the sqs broker was using ResultsExpireIn as the receive message value for "VisibilityTimeout", which defaults to 0 and overrides the visibility timeout setting on the queue which has the side effect of processing a task multiple times before deletion (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)

I've replaced the sqs broker's use of ResultsExpireIn with an optional VisibilityTimeout pointer field on SQSConfig so that when nil, the queue's visibility timeout setting is used.