### PR TITLE
SQS Broker: optional throttle in seconds for consumption errors

### DIFF
--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -78,6 +78,7 @@ func (b *AWSSQSBroker) StartConsuming(consumerTag string, concurrency int, taskP
 			default:
 				output, err := b.receiveMessage(qURL)
 				if err != nil {
+					// an optional throttle between consumption errors
 					if b.Broker.cnf != nil && b.Broker.cnf.SQS != nil && b.Broker.cnf.SQS.ThrottleConsumeError > 0 {
 						delay := time.Duration(b.Broker.cnf.SQS.ThrottleConsumeError) * time.Second
 						log.ERROR.Printf("Queue consume error, retrying in %v seconds: %s", delay, err)

--- a/v1/brokers/aws_sqs.go
+++ b/v1/brokers/aws_sqs.go
@@ -78,7 +78,13 @@ func (b *AWSSQSBroker) StartConsuming(consumerTag string, concurrency int, taskP
 			default:
 				output, err := b.receiveMessage(qURL)
 				if err != nil {
-					log.ERROR.Printf("Queue consume error: %s", err)
+					if b.Broker.cnf != nil && b.Broker.cnf.SQS != nil && b.Broker.cnf.SQS.ThrottleConsumeError > 0 {
+						delay := time.Duration(b.Broker.cnf.SQS.ThrottleConsumeError) * time.Second
+						log.ERROR.Printf("Queue consume error, retrying in %v seconds: %s", delay, err)
+						time.Sleep(delay)
+					} else {
+						log.ERROR.Printf("Queue consume error: %s", err)
+					}
 					continue
 				}
 				if len(output.Messages) == 0 {

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -65,8 +65,9 @@ type DynamoDBConfig struct {
 
 // SQSConfig wraps SQS related configuration
 type SQSConfig struct {
-	Client          *sqs.SQS
-	WaitTimeSeconds int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
+	Client               *sqs.SQS
+	ThrottleConsumeError int `yaml:"throttle_consume_error" envconfig:"SQS_THROTTLE_CONSUME_ERROR"`
+	WaitTimeSeconds      int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
 	// visiblity timeout should default to nil to use the overall visibility timeout for the queue
 	VisibilityTimeout *int `yaml:"receive_visibility_timeout" envconfig:"SQS_VISIBILITY_TIMEOUT"`

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -65,7 +65,8 @@ type DynamoDBConfig struct {
 
 // SQSConfig wraps SQS related configuration
 type SQSConfig struct {
-	Client               *sqs.SQS
+	Client *sqs.SQS
+	// Delay in seconds for broker consumption errors
 	ThrottleConsumeError int `yaml:"throttle_consume_error" envconfig:"SQS_THROTTLE_CONSUME_ERROR"`
 	WaitTimeSeconds      int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html


### PR DESCRIPTION
If a worker is run at a point where your SQS queue does not exist yet, logs will be flooded with sqs.ErrCodeQueueDoesNotExist errors, or other momentary consumption errors.  This PR is intended to provide an optional delay in seconds between consumption errors.  

I thought a retry/backoff implementation would be nice, but don't have time at the moment.