### PR TITLE
add redis config

### DIFF
--- a/v1/backends/redis.go
+++ b/v1/backends/redis.go
@@ -316,7 +316,7 @@ func (b *RedisBackend) setExpirationTime(key string) error {
 // open returns or creates instance of Redis connection
 func (b *RedisBackend) open() redis.Conn {
 	if b.pool == nil {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db)
+		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.cnf.Redis)
 	}
 	if b.redsync == nil {
 		var pools = []redsync.Pool{b.pool}

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -393,7 +393,7 @@ func (b *RedisBroker) nextDelayedTask(key string) (result []byte, err error) {
 // open returns or creates instance of Redis connection
 func (b *RedisBroker) open() redis.Conn {
 	if b.pool == nil {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db)
+		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.cnf.Redis)
 	}
 	if b.redsync == nil {
 		var pools = []redsync.Pool{b.pool}

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -26,6 +26,13 @@ var (
 			TaskStatesTable: "task_states",
 			GroupMetasTable: "group_metas",
 		},
+		Redis: &RedisConfig{
+			MaxIdle:        3,
+			IdleTimeout:    240,
+			ReadTimeout:    15,
+			WriteTimeout:   15,
+			ConnectTimeout: 15,
+		},
 	}
 
 	reloadDelay = time.Second * 10
@@ -33,12 +40,13 @@ var (
 
 // Config holds all configuration for our program
 type Config struct {
-	Broker          string      `yaml:"broker" envconfig:"BROKER"`
-	DefaultQueue    string      `yaml:"default_queue" envconfig:"DEFAULT_QUEUE"`
-	ResultBackend   string      `yaml:"result_backend" envconfig:"RESULT_BACKEND"`
-	ResultsExpireIn int         `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
-	AMQP            *AMQPConfig `yaml:"amqp"`
-	SQS             *SQSConfig  `yaml:"sqs"`
+	Broker          string       `yaml:"broker" envconfig:"BROKER"`
+	DefaultQueue    string       `yaml:"default_queue" envconfig:"DEFAULT_QUEUE"`
+	ResultBackend   string       `yaml:"result_backend" envconfig:"RESULT_BACKEND"`
+	ResultsExpireIn int          `yaml:"results_expire_in" envconfig:"RESULTS_EXPIRE_IN"`
+	AMQP            *AMQPConfig  `yaml:"amqp"`
+	SQS             *SQSConfig   `yaml:"sqs"`
+	Redis           *RedisConfig `yaml:"redis"`
 	TLSConfig       *tls.Config
 	//NoUnixSignals when set disables signal handling in machinery
 	NoUnixSignals bool            `yaml:"no_unix_signals" envconfig:"NO_UNIX_SIGNALS"`
@@ -70,6 +78,34 @@ type SQSConfig struct {
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
 	// visiblity timeout should default to nil to use the overall visibility timeout for the queue
 	VisibilityTimeout *int `yaml:"receive_visibility_timeout" envconfig:"SQS_VISIBILITY_TIMEOUT"`
+}
+
+type RedisConfig struct {
+	// Maximum number of idle connections in the pool.
+	MaxIdle int `yaml:"max_idle" envconfig:"REDIS_MAX_IDLE"`
+
+	// Maximum number of connections allocated by the pool at a given time.
+	// When zero, there is no limit on the number of connections in the pool.
+	MaxActive int `yaml:"max_active" envconfig:"REDIS_MAX_ACTIVE"`
+
+	// Close connections after remaining idle for this duration in seconds. If the value
+	// is zero, then idle connections are not closed. Applications should set
+	// the timeout to a value less than the server's timeout.
+	IdleTimeout int `yaml:"max_idle_timeout" envconfig:"REDIS_IDLE_TIMEOUT"`
+
+	// If Wait is true and the pool is at the MaxActive limit, then Get() waits
+	// for a connection to be returned to the pool before returning.
+	Wait bool `yaml:"wait" envconfig:"REDIS_WAIT"`
+
+	// ReadTimeout specifies the timeout in seconds for reading a single command reply.
+	ReadTimeout int `yaml:"read_timeout" envconfig:"REDIS_READ_TIMEOUT"`
+
+	// WriteTimeout specifies the timeout in seconds for writing a single command.
+	WriteTimeout int `yaml:"write_timeout" envconfig:"REDIS_WRITE_TIMEOUT"`
+
+	// ConnectTimeout specifies the timeout in seconds for connecting to the Redis server when
+	// no DialNetDial option is specified.
+	ConnectTimeout int `yaml:"connect_timeout" envconfig:"REDIS_CONNECT_TIMEOUT"`
 }
 
 // Decode from yaml to map (any field whose type or pointer-to-type implements


### PR DESCRIPTION
At some time, we need to limit the redis pool size and number of idle connections to support different application scenarios. This PR is to export the arguments of redis pool and connection. Machinery uses the default redis config If you don’t need to customize the arguments of redis pool.