### PR TITLE
Make delayed tasks polling period configurable for the redis backend

### DIFF
--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -346,10 +346,9 @@ func (b *RedisBroker) nextDelayedTask(key string) (result []byte, err error) {
 	)
 
 	for {
-		// Space out queries to ZSET to 20ms intervals so we don't bombard redis
+		// Space out queries to ZSET so we don't bombard redis
 		// server with relentless ZRANGEBYSCOREs
-		time.Sleep(20 * time.Millisecond)
-
+		time.Sleep(time.Duration(b.cnf.Redis.DelayedTasksPollPeriod) * time.Millisecond)
 		if _, err = conn.Do("WATCH", key); err != nil {
 			return
 		}

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -345,10 +345,15 @@ func (b *RedisBroker) nextDelayedTask(key string) (result []byte, err error) {
 		reply interface{}
 	)
 
+	var pollPeriod = 20 // default poll period for delayed tasks
+	if b.cnf != nil && b.cnf.Redis != nil {
+		pollPeriod = b.cnf.Redis.DelayedTasksPollPeriod
+	}
+
 	for {
 		// Space out queries to ZSET so we don't bombard redis
 		// server with relentless ZRANGEBYSCOREs
-		time.Sleep(time.Duration(b.cnf.Redis.DelayedTasksPollPeriod) * time.Millisecond)
+		time.Sleep(time.Duration(pollPeriod) * time.Millisecond)
 		if _, err = conn.Do("WATCH", key); err != nil {
 			return
 		}

--- a/v1/common/redis.go
+++ b/v1/common/redis.go
@@ -9,11 +9,12 @@ import (
 
 var (
 	defaultConfig = &config.RedisConfig{
-		MaxIdle:        3,
-		IdleTimeout:    240,
-		ReadTimeout:    15,
-		WriteTimeout:   15,
-		ConnectTimeout: 15,
+		MaxIdle:                3,
+		IdleTimeout:            240,
+		ReadTimeout:            15,
+		WriteTimeout:           15,
+		ConnectTimeout:         15,
+		DelayedTasksPollPeriod: 20,
 	}
 )
 

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -27,11 +27,12 @@ var (
 			GroupMetasTable: "group_metas",
 		},
 		Redis: &RedisConfig{
-			MaxIdle:        3,
-			IdleTimeout:    240,
-			ReadTimeout:    15,
-			WriteTimeout:   15,
-			ConnectTimeout: 15,
+			MaxIdle:                3,
+			IdleTimeout:            240,
+			ReadTimeout:            15,
+			WriteTimeout:           15,
+			ConnectTimeout:         15,
+			DelayedTasksPollPeriod: 20,
 		},
 	}
 
@@ -106,6 +107,9 @@ type RedisConfig struct {
 	// ConnectTimeout specifies the timeout in seconds for connecting to the Redis server when
 	// no DialNetDial option is specified.
 	ConnectTimeout int `yaml:"connect_timeout" envconfig:"REDIS_CONNECT_TIMEOUT"`
+
+	// DelayedTasksPollPeriod specifies the period in milliseconds when polling redis for delayed tasks
+	DelayedTasksPollPeriod int
 }
 
 // Decode from yaml to map (any field whose type or pointer-to-type implements


### PR DESCRIPTION
Hi,

As of now, using redis as a backend, delayed tasks are implemented by polling every 20 milliseconds for tasks to add to worker queues for consumption. This can represent up to 200 read ops / second on redis, which is I think a bit heavy, especially for people who don't use delayed tasks or who don't need sub-second precision for the execution of their delayed tasks. This PR makes this polling period configurable, while keeping the default to 20  ms, therefore not changing the current behaviour.
