### PR TITLE
[WIP] fix concurrent issues in broker

### DIFF
--- a/v1/brokers/broker.go
+++ b/v1/brokers/broker.go
@@ -21,7 +21,10 @@ type Broker struct {
 
 // New creates new Broker instance
 func New(cnf *config.Config) Broker {
-	return Broker{cnf: cnf, retry: true}
+	b := Broker{cnf: cnf, retry: true}
+	b.stopChan = make(chan int)
+	b.retryStopChan = make(chan int)
+	return b
 }
 
 // GetConfig returns config
@@ -69,9 +72,6 @@ func (b *Broker) startConsuming(consumerTag string, taskProcessor TaskProcessor)
 	if b.retryFunc == nil {
 		b.retryFunc = retry.Closure()
 	}
-
-	b.stopChan = make(chan int)
-	b.retryStopChan = make(chan int)
 }
 
 // stopConsuming is a common part of StopConsuming

--- a/v1/brokers/redis.go
+++ b/v1/brokers/redis.go
@@ -42,6 +42,9 @@ func NewRedisBroker(cnf *config.Config, host, password, socketPath string, db in
 	b.db = db
 	b.password = password
 	b.socketPath = socketPath
+	// Channels used to properly close down goroutines
+	b.stopReceivingChan = make(chan int)
+	b.stopDelayedChan = make(chan int)
 
 	return b
 }
@@ -62,9 +65,7 @@ func (b *RedisBroker) StartConsuming(consumerTag string, concurrency int, taskPr
 		return b.retry, err
 	}
 
-	// Channels and wait groups used to properly close down goroutines
-	b.stopReceivingChan = make(chan int)
-	b.stopDelayedChan = make(chan int)
+	// Wait groups used to properly close down goroutines
 	b.receivingWG.Add(1)
 	b.delayedWG.Add(1)
 


### PR DESCRIPTION
This PR fixed some concurrent issues when launching a worker asynchronously and stopping worker at the same time.
1. broker.StopConsuming function will be blocked if signal channels, like `stopChan`, not initialized yet in broker.StartConsuming function.
2. In SQS broker, stopping receive process should be done before stopping delivery process. Otherwise, goroutine in sqsBroker.StartComsuming function will be blocked by `deliveries <- output`.