### PR TITLE
fix(redis-broker): get all pending tasks

### DIFF
--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -224,7 +224,7 @@ func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	if queue == "" {
 		queue = b.GetConfig().DefaultQueue
 	}
-	dataBytes, err := conn.Do("LRANGE", queue, 0, 10)
+	dataBytes, err := conn.Do("LRANGE", queue, 0, -1)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fetch the full list instead of just the first 11

From https://redis.io/commands/lrange:
>These offsets can also be negative numbers indicating offsets starting at the end of the list. For example, -1 is the last element of the list, -2 the penultimate, and so on.