### PR TITLE
Allow custom AWS session for DynamoDB

### DIFF
--- a/v1/backends/dynamodb/dynamodb.go
+++ b/v1/backends/dynamodb/dynamodb.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/backends/iface"
@@ -11,7 +12,6 @@ import (
 	"github.com/RichardKnop/machinery/v1/log"
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -20,18 +20,23 @@ import (
 // Backend ...
 type Backend struct {
 	common.Backend
-	cnf     *config.Config
-	client  dynamodbiface.DynamoDBAPI
-	session *session.Session
+	cnf    *config.Config
+	client dynamodbiface.DynamoDBAPI
 }
 
 // New creates a Backend instance
 func New(cnf *config.Config) iface.Backend {
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
-	dy := dynamodb.New(sess)
-	backend := &Backend{Backend: common.NewBackend(cnf), cnf: cnf, client: dy, session: sess}
+	backend := &Backend{Backend: common.NewBackend(cnf), cnf: cnf}
+
+	if cnf.DynamoDB != nil && cnf.DynamoDB.Config != nil {
+		backend.client = cnf.DynamoDB.Config
+	} else {
+		sess := session.Must(session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+		backend.client = dynamodb.New(sess)
+	}
+
 	// Check if needed tables exist
 	err := backend.checkRequiredTablesIfExist()
 	if err != nil {

--- a/v1/backends/dynamodb/dynamodb_export_test.go
+++ b/v1/backends/dynamodb/dynamodb_export_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
@@ -16,7 +15,6 @@ var (
 	TestDynamoDBBackend    *Backend
 	TestErrDynamoDBBackend *Backend
 	TestCnf                *config.Config
-	TestSession            *session.Session
 	TestDBClient           dynamodbiface.DynamoDBAPI
 	TestErrDBClient        dynamodbiface.DynamoDBAPI
 	TestGroupMeta          *tasks.GroupMeta
@@ -157,14 +155,11 @@ func init() {
 			GroupMetasTable: "group_metas",
 		},
 	}
-	TestSession := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
 	TestDBClient = new(TestDynamoDBClient)
-	TestDynamoDBBackend = &Backend{cnf: TestCnf, client: TestDBClient, session: TestSession}
+	TestDynamoDBBackend = &Backend{cnf: TestCnf, client: TestDBClient}
 
 	TestErrDBClient = new(TestErrDynamoDBClient)
-	TestErrDynamoDBBackend = &Backend{cnf: TestCnf, client: TestErrDBClient, session: TestSession}
+	TestErrDynamoDBBackend = &Backend{cnf: TestCnf, client: TestErrDBClient}
 
 	TestGroupMeta = &tasks.GroupMeta{
 		GroupUUID: "testGroupUUID",
@@ -178,10 +173,6 @@ func (b *Backend) GetConfig() *config.Config {
 
 func (b *Backend) GetClient() dynamodbiface.DynamoDBAPI {
 	return b.client
-}
-
-func (b *Backend) GetSession() *session.Session {
-	return b.session
 }
 
 func (b *Backend) GetGroupMetaForTest(groupUUID string) (*tasks.GroupMeta, error) {

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"strings"
 	"time"
 
@@ -68,6 +69,7 @@ type AMQPConfig struct {
 
 // DynamoDBConfig wraps DynamoDB related configuration
 type DynamoDBConfig struct {
+	Config          *dynamodb.DynamoDB
 	TaskStatesTable string `yaml:"task_states_table" envconfig:"TASK_STATES_TABLE"`
 	GroupMetasTable string `yaml:"group_metas_table" envconfig:"GROUP_METAS_TABLE"`
 }


### PR DESCRIPTION
It occurred to me that we are able to set custom AWS session config for SQS but not DynamoDB. I required this in some work so I've forked and added it.