### PR TITLE
Added amqp connection caching

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -157,12 +157,16 @@ func (b *Broker) GetOrOpenConnection(queueName string, queueBindingKey string, e
 }
 
 func (b *Broker) CloseConnections() error {
-	for _, conn := range b.connections {
+	b.connectionsMutex.Lock()
+	defer b.connectionsMutex.Unlock()
+
+	for key, conn := range b.connections {
 		if err := b.Close(conn.channel, conn.connection); err != nil {
 			log.ERROR.Print("Failed to close channel")
 			return nil
 		}
 		close(conn.cleanup)
+		delete(b.connections, key)
 	}
 	return nil
 }

--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -171,7 +171,6 @@ func (b *Broker) CloseConnections() error {
 func (b *Broker) Publish(signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.AdjustRoutingKey(signature)
-	log.INFO.Printf("Publishing: %v", signature)
 
 	msg, err := json.Marshal(signature)
 	if err != nil {
@@ -344,34 +343,16 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 		"x-expires": delayMs * 2,
 	}
 	connection, err := b.GetOrOpenConnection(queueName,
-		queueName,        //queue binding key
+		queueName,        // queue binding key
 		nil,              // exchange declare args
 		declareQueueArgs, // queue declare arghs
 		amqp.Table(b.GetConfig().AMQP.QueueBindingArgs), // queue binding args
-
 	)
 	if err != nil {
 		return err
 	}
 
 	channel := connection.channel
-	conn, channel, _, _, _, err := b.Connect(
-		b.GetConfig().Broker,
-		b.GetConfig().TLSConfig,
-		b.GetConfig().AMQP.Exchange,     // exchange name
-		b.GetConfig().AMQP.ExchangeType, // exchange type
-		queueName,                       // queue name
-		true,                            // queue durable
-		false,                           // queue delete when unused
-		queueName,                       // queue binding key
-		nil,                             // exchange declare args
-		declareQueueArgs,                // queue declare args
-		amqp.Table(b.GetConfig().AMQP.QueueBindingArgs), // queue binding args
-	)
-	if err != nil {
-		return err
-	}
-	defer b.Close(channel, conn)
 
 	if err := channel.Publish(
 		b.GetConfig().AMQP.Exchange, // exchange


### PR DESCRIPTION
On our internal project, we found that creating a new connection for each machinery task was gradually overloading our feeble rabbitmq server (there may be other systemic problems in our codebase that lead to this, but this was one of the hypothesised causes).

This PR attempts to also address issue https://github.com/RichardKnop/machinery/issues/326. 

The implemented solution uses a simple mapping to cache connections on each queue. The connections are not closed after the task completes, allow the caller to reuse the connection with later `Publish()` calls.

Some potential issues and concerns I have with my patch (which I would appreciate input on)
1. I am not sure whether the mutex is necessary. The hypothesised race condition occurs when two goroutines attempt to GetOrOpenConnection at the same time, and both create a connection. This would leave a dangling/zombie/unreferenced connection that cannot be closed. The mutex  may make multi-threaded calls to Publish slower. 
2. I am not sure how to gracefully handle closing the connections. I have written `CloseConnections` however, given that a `machinery.Server` does not provide a `shutdown()` method or interface, I'm not sure how to approach gracefully terminating these connections. RabbitMQ currently reports that the client unexpected closed our TCP connection.
3. I am not sure how to write tests mocking only a single TCP connection.

Testing Criteria: 
* Re run example applications. Notice that only a single AMQP connection is created.