### PR TITLE
Broker is now using stopChan in a non-blocking mode

### DIFF
--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -96,7 +96,11 @@ func (b *Broker) StopConsuming() {
 	default:
 	}
 	// Notifying the stop channel stops consuming of messages
-	b.stopChan <- 1
+	select {
+	case b.stopChan <- 1:
+		log.WARNING.Print("Stop channel")
+	default:
+	}
 }
 
 // GetRegisteredTaskNames returns registered tasks names


### PR DESCRIPTION
Fix for [issue 346](https://github.com/RichardKnop/machinery/issues/346). Worker is now using stopChan in a non-blocking mode.