### PR TITLE
Do not use Machinery's GroupUUID to set SQS MessageGroupID attribute.

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -142,7 +142,7 @@ func (b *Broker) Publish(signature *tasks.Signature) error {
 		MsgDedupID := signature.UUID
 		MsgInput.MessageDeduplicationId = aws.String(MsgDedupID)
 
-		// Use Machinery's signature Group UUID as SQS Message Group ID.
+		// Do not Use Machinery's signature Group UUID as SQS Message Group ID, instead use BrokerMessageGroupId
 		MsgGroupID := signature.BrokerMessageGroupId
 		if MsgGroupID == "" {
 			return fmt.Errorf("please specify BrokerMessageGroupId attribute for task Signature when submitting a task to FIFO queue")

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -143,7 +143,10 @@ func (b *Broker) Publish(signature *tasks.Signature) error {
 		MsgInput.MessageDeduplicationId = aws.String(MsgDedupID)
 
 		// Use Machinery's signature Group UUID as SQS Message Group ID.
-		MsgGroupID := signature.GroupUUID
+		MsgGroupID := signature.BrokerMessageGroupId
+		if MsgGroupID == "" {
+			return fmt.Errorf("please specify BrokerMessageGroupId attribute for task Signature when submitting a task to FIFO queue")
+		}
 		MsgInput.MessageGroupId = aws.String(MsgGroupID)
 	}
 

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -57,6 +57,8 @@ type Signature struct {
 	OnSuccess      []*Signature
 	OnError        []*Signature
 	ChordCallback  *Signature
+	//MessageGroupId for Broker, e.g. SQS
+	BrokerMessageGroupId string
 }
 
 // NewSignature creates a new task signature


### PR DESCRIPTION
Introduce a new attribute 'BrokerMessageGroupID' on task.Signature that should be used for specifying sqs.MessageGroupId when submitting tasks to a FIFO SQS queue.


When sending a message to FIFO queue if no `BrokerMessageGroupId` attribute is specified, `m.server.SendTask` will return error like:

`Publish message error: please specify BrokerMessageGroupId attribute for task Signature when submitting a task to FIFO queue`

To submit a Job to Fifo sqs queue, task Signature must specify `BrokerMessageGroupId` attribute.
e.g.

```
task := tasks.Signature{
		Name: "name",
		Args: []tasks.Arg{
			{
				Name:  "payload",
				Type:  "string",
				Value: "payload",
			},
		},

		BrokerMessageGroupId: "sqs-group",
	}
```