### PR TITLE
367 Fix NewCustomQueueWorker() functionality with sqs broker

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -62,7 +62,8 @@ func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)
-	qURL := b.defaultQueueURL()
+	qURL := b.getQueueURL(taskProcessor)
+
 	deliveries := make(chan *awssqs.ReceiveMessageOutput)
 
 	b.stopReceivingChan = make(chan int)
@@ -71,7 +72,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	go func() {
 		defer b.receivingWG.Done()
 
-		log.INFO.Print("[*] Waiting for messages. To exit press CTRL+C")
+		log.INFO.Printf("[*] Waiting for messages on queue: %s. To exit press CTRL+C\n", *qURL)
 
 		for {
 			select {
@@ -343,4 +344,15 @@ func (b *Broker) continueReceivingMessages(qURL *string, deliveries chan *awssqs
 func (b *Broker) stopReceiving() {
 	// Stop the receiving goroutine
 	b.stopReceivingChan <- 1
+}
+
+// getQueueURL is a method returns that returns queueURL first by checking if custom queue was set and usign it
+// otherwise using default queueName from config
+func (b *Broker) getQueueURL(taskProcessor iface.TaskProcessor) *string {
+	queueName := b.GetConfig().DefaultQueue
+	if taskProcessor.CustomQueue() != "" {
+		queueName = taskProcessor.CustomQueue()
+	}
+
+	return aws.String(b.GetConfig().Broker + "/" + queueName)
 }

--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -181,3 +181,12 @@ func (b *Broker) GetStopChanForTest() chan int {
 func (b *Broker) GetRetryStopChanForTest() chan int {
 	return b.GetRetryStopChan()
 }
+
+func (b *Broker) GetQueueURLForTest(taskProcessor iface.TaskProcessor) *string {
+	return b.getQueueURL(taskProcessor)
+}
+
+
+func (b *Broker) GetCustomQueueURL(customQueue string) *string {
+	return aws.String(b.GetConfig().Broker + "/" + customQueue)
+}

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -228,3 +228,20 @@ func TestPrivateFunc_deleteOne(t *testing.T) {
 	err = errAWSSQSBroker.DeleteOneForTest(receiveMessageOutput)
 	assert.NotNil(t, err)
 }
+
+
+func Test_CustomQueueName(t *testing.T) {
+	server1, err := machinery.NewServer(cnf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wk := server1.NewWorker("test-worker", 0)
+	qURL := testAWSSQSBroker.GetQueueURLForTest(wk)
+	assert.Equal(t, qURL, testAWSSQSBroker.DefaultQueueURLForTest(), "")
+
+
+	wk2 := server1.NewCustomQueueWorker("test-worker", 0, "my-custom-queue")
+	qURL2 := testAWSSQSBroker.GetQueueURLForTest(wk2)
+	assert.Equal(t, qURL2, testAWSSQSBroker.GetCustomQueueURL("my-custom-queue"), "")
+}


### PR DESCRIPTION
When using SQS broker make sure worker started with server.NewCustomQueueWorker() listens on custom queue specified as function argument and not on default queue specified in config

cc @RichardKnop  this fixes #367 