### PR TITLE
Updating the state inside a lock to avoid concurrent writes

### DIFF
--- a/v1/backends/eager/eager.go
+++ b/v1/backends/eager/eager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/RichardKnop/machinery/v1/backends/iface"
 	"github.com/RichardKnop/machinery/v1/common"
@@ -44,8 +45,9 @@ func (e ErrTasknotFound) Error() string {
 // Backend represents an "eager" in-memory result backend
 type Backend struct {
 	common.Backend
-	groups map[string][]string
-	tasks  map[string][]byte
+	groups     map[string][]string
+	tasks      map[string][]byte
+	stateMutex sync.Mutex
 }
 
 // New creates EagerBackend instance
@@ -196,11 +198,13 @@ func (b *Backend) PurgeGroupMeta(groupUUID string) error {
 
 func (b *Backend) updateState(s *tasks.TaskState) error {
 	// simulate the behavior of json marshal/unmarshal
+	b.stateMutex.Lock()
 	msg, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Errorf("Marshal task state error: %v", err)
 	}
 
 	b.tasks[s.TaskUUID] = msg
+	b.stateMutex.Unlock()
 	return nil
 }


### PR DESCRIPTION
I am getting the following error when I run machinery worker with too many tasks.

```
019-01-08T18:17:13.482+0500    INFO    redis/redis.go:305    Received new message: {"UUID":"task_b8981ac5-211c-4142-ac6b-962e7ca66154","Name":"some_async_task",.....ChordCallback":null,"BrokerMessageGroupId":"c246a11a-e216-4217-ae4d-4738165b3518"}
fatal error: concurrent map writes

goroutine 1748 [running]:userxyz
runtime.throw(0x502eb4d, 0x15)
    /usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc000737a30 sp=0xc000737a00 pc=0x402dd12
runtime.mapassign_faststr(0x4e4d020, 0xc0006569f0, 0xc000911110, 0x29, 0xa0)
    /usr/local/go/src/runtime/map_faststr.go:275 +0x3bf fp=0xc000737a98 sp=0xc000737a30 pc=0x401462f
github.com/RichardKnop/machinery/v1/backends/eager.(*Backend).updateState(0xc00064c980, 0xc0000c04d0, 0x402d301, 0x529d268)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/backends/eager/eager.go:204 +0x112 fp=0xc000737b08 sp=0xc000737a98 pc=0x4b68b72
github.com/RichardKnop/machinery/v1/backends/eager.(*Backend).SetStateSuccess(0xc00064c980, 0xc00075a340, 0x5d4d620, 0x0, 0x0, 0x4abdbdf, 0x5d4d620)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/backends/eager/eager.go:149 +0xa9 fp=0xc000737b38 sp=0xc000737b08 pc=0x4b68419
github.com/RichardKnop/machinery/v1.(*Worker).taskSucceeded(0xc0003c3e50, 0xc00075a340, 0x5d4d620, 0x0, 0x0, 0x0, 0x0)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/worker.go:236 +0x8e fp=0xc000737cd0 sp=0xc000737b38 pc=0x4b7f6be
github.com/RichardKnop/machinery/v1.(*Worker).Process(0xc0003c3e50, 0xc00075a340, 0x0, 0x0)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/worker.go:187 +0x6a4 fp=0xc000737e40 sp=0xc000737cd0 pc=0x4b7ed14
github.com/RichardKnop/machinery/v1/brokers/redis.(*Broker).consumeOne(0xc0002e5080, 0xc000756000, 0x558, 0x558, 0x5289840, 0xc0003c3e50, 0x0, 0x0)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/brokers/redis/redis.go:307 +0x23f fp=0xc000737f38 sp=0xc000737e40 pc=0x4af426f
github.com/RichardKnop/machinery/v1/brokers/redis.(*Broker).consume.func1(0xc0002e5080, 0xc000756000, 0x558, 0x558, 0x5289840, 0xc0003c3e50, 0xc00068e180, 0x0, 0xc00068e120)
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/brokers/redis/redis.go:269 +0x67 fp=0xc000737f98 sp=0xc000737f38 pc=0x4af5a77
runtime.goexit()
    /usr/local/go/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc000737fa0 sp=0xc000737f98 pc=0x405c541
created by github.com/RichardKnop/machinery/v1/brokers/redis.(*Broker).consume
    /Users/userxyz/Documents/myworkspace/go/pkg/mod/github.com/!richard!knop/machinery@v1.5.4/v1/brokers/redis/redis.go:268 +0x106
```

This PR introduces a mutex lock while updating task state.