### PR TITLE
Add TLS support for Redis backend and broker

### DIFF
--- a/v1/backends/redis/redis.go
+++ b/v1/backends/redis/redis.go
@@ -329,7 +329,7 @@ func (b *Backend) setExpirationTime(key string) error {
 // open returns or creates instance of Redis connection
 func (b *Backend) open() redis.Conn {
 	if b.pool == nil {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis)
+		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 	}
 	if b.redsync == nil {
 		var pools = []redsync.Pool{b.pool}

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -399,7 +399,7 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 // open returns or creates instance of Redis connection
 func (b *Broker) open() redis.Conn {
 	if b.pool == nil {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis)
+		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 	}
 	if b.redsync == nil {
 		var pools = []redsync.Pool{b.pool}


### PR DESCRIPTION
Early last year AWS released [Redis In-Transit Encryption for Elasticache.](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html) When this is turned on, you must have a TLS configured on your client in order to connect. 

I have added support to configure TLS for the redis backend and broker the same way you can configure it currently for mongo and amqp. 