### PR TITLE
Add context to Publish method for tracing purposes.

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -177,7 +178,7 @@ func (b *Broker) CloseConnections() error {
 }
 
 // Publish places a new message on the default queue
-func (b *Broker) Publish(signature *tasks.Signature) error {
+func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.AdjustRoutingKey(signature)
 

--- a/v1/brokers/eager/eager.go
+++ b/v1/brokers/eager/eager.go
@@ -2,6 +2,7 @@ package eager
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,7 +39,7 @@ func (eagerBroker *Broker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (eagerBroker *Broker) Publish(task *tasks.Signature) error {
+func (eagerBroker *Broker) Publish(ctx context.Context, task *tasks.Signature) error {
 	if eagerBroker.worker == nil {
 		return errors.New("worker is not assigned in eager-mode")
 	}

--- a/v1/brokers/gcppubsub/gcp_pubsub.go
+++ b/v1/brokers/gcppubsub/gcp_pubsub.go
@@ -111,7 +111,7 @@ func (b *Broker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (b *Broker) Publish(signature *tasks.Signature) error {
+func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.AdjustRoutingKey(signature)
 
@@ -119,8 +119,6 @@ func (b *Broker) Publish(signature *tasks.Signature) error {
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
 	}
-
-	ctx := context.Background()
 
 	defaultQueue := b.GetConfig().DefaultQueue
 	topic := b.service.Topic(defaultQueue)

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -1,6 +1,8 @@
 package iface
 
 import (
+	"context"
+
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
 )
@@ -12,7 +14,7 @@ type Broker interface {
 	IsTaskRegistered(name string) bool
 	StartConsuming(consumerTag string, concurrency int, p TaskProcessor) (bool, error)
 	StopConsuming()
-	Publish(task *tasks.Signature) error
+	Publish(ctx context.Context, task *tasks.Signature) error
 	GetPendingTasks(queue string) ([]*tasks.Signature, error)
 	AdjustRoutingKey(s *tasks.Signature)
 }

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -152,7 +153,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 					log.ERROR.Print(errs.NewErrCouldNotUnmarshaTaskSignature(task, err))
 				}
 
-				if err := b.Publish(signature); err != nil {
+				if err := b.Publish(context.Background(), signature); err != nil {
 					log.ERROR.Print(err)
 				}
 			}
@@ -188,7 +189,7 @@ func (b *Broker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (b *Broker) Publish(signature *tasks.Signature) error {
+func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error {
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.Broker.AdjustRoutingKey(signature)
 

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -1,6 +1,7 @@
 package sqs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -126,7 +127,7 @@ func (b *Broker) StopConsuming() {
 }
 
 // Publish places a new message on the default queue
-func (b *Broker) Publish(signature *tasks.Signature) error {
+func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error {
 	msg, err := json.Marshal(signature)
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
@@ -167,7 +168,7 @@ func (b *Broker) Publish(signature *tasks.Signature) error {
 		}
 	}
 
-	result, err := b.service.SendMessage(MsgInput)
+	result, err := b.service.SendMessageWithContext(ctx, MsgInput)
 
 	if err != nil {
 		log.ERROR.Printf("Error when sending a message: %v", err)


### PR DESCRIPTION
Passing the context when `Publishing`  jobs allows tracing to be all under one trace. This change is mostly useful for `PubSub` and `SQS` right now since they are the only ones tracing requests going out.