### PR TITLE
Task middleware + custom panic handler

### DIFF
--- a/v1/tasks/task_test.go
+++ b/v1/tasks/task_test.go
@@ -17,7 +17,7 @@ func TestTaskCallErrorTest(t *testing.T) {
 	// Create test task that returns tasks.ErrRetryTaskLater error
 	retriable := func() error { return tasks.NewErrRetryTaskLater("some error", 4*time.Hour) }
 
-	task, err := tasks.New(retriable, []tasks.Arg{})
+	task, err := tasks.New(retriable, []tasks.Arg{}, nil)
 	assert.NoError(t, err)
 
 	// Invoke TryCall and validate that returned error can be cast to tasks.ErrRetryTaskLater
@@ -30,7 +30,7 @@ func TestTaskCallErrorTest(t *testing.T) {
 	// Create test task that returns a standard error
 	standard := func() error { return errors.New("some error") }
 
-	task, err = tasks.New(standard, []tasks.Arg{})
+	task, err = tasks.New(standard, []tasks.Arg{}, nil)
 	assert.NoError(t, err)
 
 	// Invoke TryCall and validate that returned error is standard
@@ -68,7 +68,7 @@ func TestTaskCallInvalidArgRobustnessError(t *testing.T) {
 		{Type: "bool", Value: true},
 	}
 
-	task, err := tasks.New(f, args)
+	task, err := tasks.New(f, args, nil)
 	assert.NoError(t, err)
 
 	// Invoke TryCall and validate error handling
@@ -83,7 +83,7 @@ func TestTaskCallInterfaceValuedResult(t *testing.T) {
 	// Create a test task function
 	f := func() (interface{}, error) { return math.Pi, nil }
 
-	task, err := tasks.New(f, []tasks.Arg{})
+	task, err := tasks.New(f, []tasks.Arg{}, nil)
 	assert.NoError(t, err)
 
 	taskResults, err := task.Call()
@@ -99,7 +99,7 @@ func TestTaskCallWithContext(t *testing.T) {
 		assert.NotNil(t, c)
 		return math.Pi, nil
 	}
-	task, err := tasks.New(f, []tasks.Arg{})
+	task, err := tasks.New(f, []tasks.Arg{}, nil)
 	assert.NoError(t, err)
 	taskResults, err := task.Call()
 	assert.NoError(t, err)

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -41,6 +41,7 @@ type Worker struct {
 	preTaskHandler  func(*tasks.Signature)
 	postTaskHandler func(*tasks.Signature)
 	taskCaller      TaskCaller
+	panicHandler    tasks.PanicHandler
 }
 
 // Launch starts a new worker process. The worker subscribes
@@ -151,7 +152,7 @@ func (worker *Worker) Process(signature *tasks.Signature) error {
 	}
 
 	// Prepare task for processing
-	task, err := tasks.New(taskFunc, signature.Args)
+	task, err := tasks.New(taskFunc, signature.Args, worker.panicHandler)
 	// if this failed, it means the task is malformed, probably has invalid
 	// signature, go directly to task failed without checking whether to retry
 	if err != nil {
@@ -407,8 +408,14 @@ func (worker *Worker) SetPostTaskHandler(handler func(*tasks.Signature)) {
 	worker.postTaskHandler = handler
 }
 
+// SetTaskCaller sets a custom handler for calling the task.
 func (worker *Worker) SetTaskCaller(taskCaller TaskCaller) {
 	worker.taskCaller = taskCaller
+}
+
+// SetPanicHandler sets a custom handler to recovering from panics during task calls.
+func (worker *Worker) SetPanicHandler(panicHandler tasks.PanicHandler) {
+	worker.panicHandler = panicHandler
 }
 
 //GetServer returns server

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -1,0 +1,73 @@
+package machinery_test
+
+import (
+	"testing"
+
+	"github.com/RichardKnop/machinery/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RichardKnop/machinery/v1/tasks"
+)
+
+func TestProcess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("use default task caller", func(t *testing.T) {
+		callCount := 0
+		server := getTestServer(t)
+
+		dummyTask := func(a uint64) (uint64, error) {
+			callCount++
+			return a + 1, nil
+		}
+		assert.NoError(t, server.RegisterTask("Dummy", dummyTask))
+
+		worker := server.NewWorker("test_worker", 1)
+
+		err := worker.Process(&tasks.Signature{
+			Name: "Dummy",
+			Args: []tasks.Arg{{Type: "uint64", Value: uint64(3)}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("use custom task caller", func(t *testing.T) {
+		middlewareCallCount := 0
+		callCount := 0
+		server := getTestServer(t)
+
+		dummyTask := func(a uint64) (uint64, error) {
+			callCount++
+			return a + 1, nil
+		}
+		assert.NoError(t, server.RegisterTask("Dummy", dummyTask))
+
+		worker := server.NewWorker("test_worker", 1)
+		worker.SetTaskCaller(machinery.TaskCallerFunc(func(signature *tasks.Signature, task *tasks.Task) (results []*tasks.TaskResult, e error) {
+			middlewareCallCount++
+
+			if signature.Args[0].Value == uint64(1000) {
+				// Abort task processing.
+				return nil, nil
+			}
+
+			return machinery.DefaultTaskCaller.Call(signature, task)
+		}))
+
+		assert.NoError(t, worker.Process(&tasks.Signature{
+			Name: "Dummy",
+			Args: []tasks.Arg{{Type: "uint64", Value: uint64(3)}},
+		}))
+		assert.Equal(t, 1, middlewareCallCount)
+		assert.Equal(t, 1, callCount)
+
+		assert.NoError(t, worker.Process(&tasks.Signature{
+			Name: "Dummy",
+			Args: []tasks.Arg{{Type: "uint64", Value: uint64(1000)}},
+		}))
+		assert.Equal(t, 2, middlewareCallCount)
+		assert.Equal(t, 1, callCount)
+	})
+}


### PR DESCRIPTION
I'm not 100% happy with the API here, but I'm putting the PR up for review and comment.

The main use-case I have is that I want to be able to access context, task/signature, and panic stack trace so that I can include all of these in error report (e.g. when sending to Bugsnag). Currently that is not possible.

This PR first adds a way to customize how tasks are called - through `Worker.SetTaskCaller`. This means we can build middleware to adjust context based on the task, or even abort task processing early (e.g. to allow dynamic "blackholing"), or to adjust input arguments or output results.

The middleware setup could fully replace the pre and post task handlers, as well as the error handler.

I thought I could make the middleware setup work for panics too, but the panic is handled inside of the task call, which I guess it needs to be to close off the tracing appropriately. That's why I added a `SetPanicHandler` too, which overrides the default behavior of just logging the panic stack trace. However, this doesn't work too nicely, because the error handler will be called after the panic handler.

My main worry is the panicHandler and errorHandler interaction. How do you think we should solve that? Does this approach, or something along these lines, make sense for machinery?