### PR TITLE
Redis backend - reset group expiry in TriggerChord

### DIFF
--- a/v1/backends/redis/redis.go
+++ b/v1/backends/redis/redis.go
@@ -133,7 +133,7 @@ func (b *Backend) TriggerChord(groupUUID string) (bool, error) {
 		return false, err
 	}
 
-	return true, nil
+	return true, b.setExpirationTime(groupUUID)
 }
 
 func (b *Backend) mergeNewTaskState(newState *tasks.TaskState) {


### PR DESCRIPTION
This fixes a bug where the group key TTL is reset to -1 by the SET call. We need to reset it back to our desired expiry after the SET call.

A future improvement could be to pass the EX option to SET instead of always doing a separate EXPIREAT for all keys.