### PR TITLE
Support context propagation with opentracing fallback.

### DIFF
--- a/v1/compat.go
+++ b/v1/compat.go
@@ -1,0 +1,87 @@
+package machinery
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"github.com/RichardKnop/machinery/v1/tracing"
+)
+
+var (
+	// These ensure opentracing is automatically called to preserve backwards-compatible behavior
+	// TODO: deprecate, or expose
+	defaultPreTaskHandler         = OpenTracingPreTaskHandler
+	defaultPostTaskHandler        = OpenTracingPostTaskHandler
+	defaultPrePublishHandler      = OpenTracingPrePublishTaskHandler
+	defaultPreGroupPublishHandler = OpenTracingPreGroupPublishTaskHandler
+	defaultPreChordPublishHandler = OpenTracingPreChordPublishTaskHandler
+	defaultPreChainPublishHandler = OpenTracingPreChainPublishTaskHandler
+)
+
+// finishFun is used by the prepublish handlers on the server
+// to ensure a function that returns nil doesn't panic
+// is this overkill for panics?
+func finishFunc(funcs ...func()) func() {
+	return func() {
+		for _, f := range funcs {
+			f := f // pin
+			if f != nil {
+				f()
+			}
+		}
+	}
+}
+
+// OpenTracingPreTaskHandler starts an opentracing span based on incoming headers
+func OpenTracingPreTaskHandler(ctx context.Context, signature *tasks.Signature) context.Context {
+	// try to extract trace span from headers and add it to the function context
+	// so it can be used inside the function if it has context.Context as the first
+	// argument. Start a new span if it isn't found.
+	taskSpan := tracing.StartSpanFromHeaders(signature.Headers, signature.Name)
+	tracing.AnnotateSpanWithSignatureInfo(taskSpan, signature)
+	return opentracing.ContextWithSpan(ctx, taskSpan)
+}
+
+// OpenTracingPostTaskHandler ends an opentracing span based on the passed in context
+func OpenTracingPostTaskHandler(ctx context.Context, _ *tasks.Signature) {
+	taskSpan := opentracing.SpanFromContext(ctx)
+	if taskSpan != nil {
+		taskSpan.Finish()
+	}
+}
+
+// OpenTracingPrePublishTaskHandler propagates opentracing information in outgoing task header information
+func OpenTracingPrePublishTaskHandler(ctx context.Context, signature *tasks.Signature) func() {
+	span, _ := opentracing.StartSpanFromContext(ctx, "SendTask", tracing.ProducerOption(), tracing.MachineryTag)
+
+	// tag the span with some info about the signature
+	signature.Headers = tracing.HeadersWithSpan(signature.Headers, span)
+
+	return span.Finish
+}
+
+// OpenTracingPreGroupPublishTaskHandler propagates opentracing information in outgoing task header information
+func OpenTracingPreGroupPublishTaskHandler(ctx context.Context, group *tasks.Group, sendConcurrency int) func() {
+	span, _ := opentracing.StartSpanFromContext(ctx, "SendGroup", tracing.ProducerOption(), tracing.MachineryTag, tracing.WorkflowGroupTag)
+
+	tracing.AnnotateSpanWithGroupInfo(span, group, sendConcurrency)
+
+	return span.Finish
+}
+
+// OpenTracingPreChainPublishTaskHandler propagates opentracing information in outgoing task header information
+func OpenTracingPreChainPublishTaskHandler(ctx context.Context, chain *tasks.Chain) func() {
+	span, _ := opentracing.StartSpanFromContext(ctx, "SendChain", tracing.ProducerOption(), tracing.MachineryTag, tracing.WorkflowChainTag)
+	tracing.AnnotateSpanWithChainInfo(span, chain)
+	return span.Finish
+}
+
+// OpenTracingPreChordPublishTaskHandler propagates opentracing information in outgoing task header information
+func OpenTracingPreChordPublishTaskHandler(ctx context.Context, chord *tasks.Chord, sendConcurrency int) func() {
+	span, _ := opentracing.StartSpanFromContext(ctx, "SendChord", tracing.ProducerOption(), tracing.MachineryTag, tracing.WorkflowChordTag)
+	tracing.AnnotateSpanWithChordInfo(span, chord, sendConcurrency)
+
+	return span.Finish
+}

--- a/v1/compat_test.go
+++ b/v1/compat_test.go
@@ -2,12 +2,14 @@ package machinery_test
 
 import (
 	"context"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/tasks"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOpenTracingPreTaskHandler(t *testing.T) {
@@ -20,5 +22,52 @@ func TestOpenTracingPreTaskHandler(t *testing.T) {
 	ctx := context.Background()
 	ctx2 := machinery.OpenTracingPreTaskHandler(ctx, sig)
 
-	assert.NotEqual(t, ctx, ctx2)
+	assert.NotEqual(t, ctx, ctx2, "OpenTracingPreTaskHandler returns a new context")
+	assert.NotNil(t, opentracing.SpanFromContext(ctx2), "context returned contains an opentracing span")
+}
+
+func TestOpenTracingPostTaskHandler(t *testing.T) {
+	t.Parallel()
+
+	mockTracer := mocktracer.New()
+	span := mockTracer.StartSpan("new task")
+	mockSpan := span.(*mocktracer.MockSpan)
+
+	assert.Zero(t, mockSpan.FinishTime, "span not finished")
+
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+	machinery.OpenTracingPostTaskHandler(ctx, sig)
+
+	assert.NotZero(t, mockSpan.FinishTime, "span finished")
+}
+
+func TestOpenTracingPrePublishHandlerAddsHeaders(t *testing.T) {
+
+	globalTracer := opentracing.GlobalTracer()
+
+	defer func() {
+		opentracing.SetGlobalTracer(globalTracer)
+	}()
+
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+
+	mockTracer := mocktracer.New()
+	opentracing.SetGlobalTracer(mockTracer)
+
+	span := mockTracer.StartSpan("new task")
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+
+	assert.Empty(t, sig.Headers)
+
+	f := machinery.OpenTracingPrePublishTaskHandler(ctx, sig)
+
+	assert.NotNil(t, f)
+
+	assert.NotEmpty(t, sig.Headers, "signature headers populated from tracing call")
 }

--- a/v1/compat_test.go
+++ b/v1/compat_test.go
@@ -1,0 +1,24 @@
+package machinery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RichardKnop/machinery/v1"
+	"github.com/RichardKnop/machinery/v1/tasks"
+)
+
+func TestOpenTracingPreTaskHandler(t *testing.T) {
+	t.Parallel()
+
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+
+	ctx := context.Background()
+	ctx2 := machinery.OpenTracingPreTaskHandler(ctx, sig)
+
+	assert.NotEqual(t, ctx, ctx2)
+}

--- a/v1/compat_test.go
+++ b/v1/compat_test.go
@@ -26,6 +26,77 @@ func TestOpenTracingPreTaskHandler(t *testing.T) {
 	assert.NotNil(t, opentracing.SpanFromContext(ctx2), "context returned contains an opentracing span")
 }
 
+func TestOpenTracingPreChainTaskHandler(t *testing.T) {
+	t.Parallel()
+
+	chain := &tasks.Chain{
+		Tasks: []*tasks.Signature{
+			{
+				Name: "abc",
+			},
+			{
+				Name: "def",
+			},
+			{
+				Name: "ghi",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	finish := machinery.OpenTracingPreChainPublishTaskHandler(ctx, chain)
+	assert.NotPanics(t, finish)
+}
+
+func TestOpenTracingPreGroupTaskHandler(t *testing.T) {
+	t.Parallel()
+
+	group := &tasks.Group{
+		Tasks: []*tasks.Signature{
+			{
+				Name: "abc",
+			},
+			{
+				Name: "def",
+			},
+			{
+				Name: "ghi",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	finish := machinery.OpenTracingPreGroupPublishTaskHandler(ctx, group, 0)
+	assert.NotPanics(t, finish)
+}
+
+func TestOpenTracingPreChordTaskHandler(t *testing.T) {
+	t.Parallel()
+
+	chord := &tasks.Chord{
+		Group: &tasks.Group{
+			Tasks: []*tasks.Signature{
+				{
+					Name: "abc",
+				},
+				{
+					Name: "def",
+				},
+				{
+					Name: "ghi",
+				},
+			},
+		},
+		Callback: &tasks.Signature{
+			Name: "callback",
+		},
+	}
+
+	ctx := context.Background()
+	finish := machinery.OpenTracingPreChordPublishTaskHandler(ctx, chord, 0)
+	assert.NotPanics(t, finish)
+}
+
 func TestOpenTracingPostTaskHandler(t *testing.T) {
 	t.Parallel()
 

--- a/v1/server_test.go
+++ b/v1/server_test.go
@@ -3,9 +3,10 @@ package machinery_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRegisterTasks(t *testing.T) {

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -1,9 +1,11 @@
 package machinery_test
 
 import (
-	"github.com/RichardKnop/machinery/v1"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RichardKnop/machinery/v1"
 )
 
 func TestRedactURL(t *testing.T) {

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -1,7 +1,14 @@
 package machinery_test
 
 import (
+	"context"
 	"testing"
+
+	eagerbackend "github.com/RichardKnop/machinery/v1/backends/eager"
+	"github.com/RichardKnop/machinery/v1/brokers/eager"
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/stretchr/testify/assert"
 
@@ -26,4 +33,77 @@ func TestPreConsumeHandler(t *testing.T) {
 
 func SamplePreConsumeHandler(w *machinery.Worker) bool {
 	return true
+}
+
+type workerSuite struct {
+	worker *machinery.Worker
+	srv    *machinery.Server
+	suite.Suite
+}
+
+func TestWorkerContextHandlers(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(workerSuite))
+}
+
+func (w *workerSuite) SetupSuite() {
+	w.srv = machinery.NewServerWithBrokerBackend(nil, eager.New(), eagerbackend.New())
+	w.worker = w.srv.NewWorker("", 1)
+}
+
+func (w *workerSuite) TestPreTaskHandler_Default() {
+	var ctx context.Context
+	_ = w.srv.RegisterTask("abc", func(c context.Context) error {
+		ctx = c
+		return nil
+	})
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+	err := w.worker.Process(sig)
+	w.NoError(err)
+	w.NotNil(ctx)
+	w.NotNil(opentracing.SpanFromContext(ctx), "opentracing span should have been passed to the context")
+}
+
+func (w *workerSuite) TestPreTaskHandler_Nil() {
+	var ctx context.Context
+
+	w.worker.SetPreTaskContextHandler(nil)
+
+	_ = w.srv.RegisterTask("abc", func(c context.Context) error {
+		ctx = c
+		return nil
+	})
+
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+
+	w.Panics(func() {
+		_ = w.worker.Process(sig)
+	})
+	w.Nil(ctx)
+}
+
+func (w *workerSuite) TestPreTaskHandler_Custom() {
+	var ctx context.Context
+
+	w.worker.SetPreTaskContextHandler(func(ctx context.Context, _ *tasks.Signature) context.Context {
+		return context.WithValue(ctx, "a", "b")
+	})
+
+	_ = w.srv.RegisterTask("abc", func(c context.Context) error {
+		ctx = c
+		return nil
+	})
+
+	sig := &tasks.Signature{
+		Name: "abc",
+	}
+	err := w.worker.Process(sig)
+	w.NoError(err)
+	w.NotNil(ctx)
+	w.NotNil(opentracing.SpanFromContext(ctx), "opentracing span should have been passed to the context")
+	w.Equal("b", ctx.Value("a"), "worker pre task function should have set a value in the task context")
 }


### PR DESCRIPTION
I took a pass at allowing modification of the context before running tasks, as well as using it in all pre publish handlers on the server. This should not be a breaking change as opentracing will continue to be used as before, just initiated differently. The only potential panic I can think of is if someone calls `Set...Handler(nil)`.

Can someone keep me honest as far as the chord, chain and group implementations go? I have mostly just used a single task at a time. The server implementation is a bit ugly, so suggestions would be welcome as well.

This relates to discussions in #384. 