### PR TITLE
inject signature into the context

### DIFF
--- a/v1/tasks/task.go
+++ b/v1/tasks/task.go
@@ -26,11 +26,11 @@ type Task struct {
 	Args       []reflect.Value
 }
 
-type signitureCtxType struct{}
+type signatureCtxType struct{}
 
-var signatureCtx signitureCtxType
+var signatureCtx signatureCtxType
 
-// SignatureFromContext gets the signiture from the context
+// SignatureFromContext gets the signature from the context
 func SignatureFromContext(ctx context.Context) *Signature {
 	if ctx == nil {
 		return nil
@@ -45,7 +45,7 @@ func SignatureFromContext(ctx context.Context) *Signature {
 	return signature
 }
 
-// NewWithSigniture is the same as New but injects the signature
+// NewWithSignature is the same as New but injects the signature
 func NewWithSignature(taskFunc interface{}, signature *Signature) (*Task, error) {
 	args := signature.Args
 	ctx := context.Background()

--- a/v1/tasks/task.go
+++ b/v1/tasks/task.go
@@ -26,6 +26,50 @@ type Task struct {
 	Args       []reflect.Value
 }
 
+type signitureCtxType struct{}
+
+var signatureCtx signitureCtxType
+
+// SignatureFromContext gets the signiture from the context
+func SignatureFromContext(ctx context.Context) *Signature {
+	if ctx == nil {
+		return nil
+	}
+
+	v := ctx.Value(signatureCtx)
+	if v == nil {
+		return nil
+	}
+
+	signature, _ := v.(*Signature)
+	return signature
+}
+
+// NewWithSigniture is the same as New but injects the signature
+func NewWithSignature(taskFunc interface{}, signature *Signature) (*Task, error) {
+	args := signature.Args
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, signatureCtx, signature)
+	task := &Task{
+		TaskFunc: reflect.ValueOf(taskFunc),
+		Context:  ctx,
+	}
+
+	taskFuncType := reflect.TypeOf(taskFunc)
+	if taskFuncType.NumIn() > 0 {
+		arg0Type := taskFuncType.In(0)
+		if IsContextType(arg0Type) {
+			task.UseContext = true
+		}
+	}
+
+	if err := task.ReflectArgs(args); err != nil {
+		return nil, fmt.Errorf("Reflect task args error: %s", err)
+	}
+
+	return task, nil
+}
+
 // New tries to use reflection to convert the function and arguments
 // into a reflect.Value and prepare it for invocation
 func New(taskFunc interface{}, args []Arg) (*Task, error) {

--- a/v1/tasks/task_test.go
+++ b/v1/tasks/task_test.go
@@ -97,9 +97,30 @@ func TestTaskCallWithContext(t *testing.T) {
 
 	f := func(c context.Context) (interface{}, error) {
 		assert.NotNil(t, c)
+		assert.Nil(t, tasks.SignatureFromContext(c))
 		return math.Pi, nil
 	}
 	task, err := tasks.New(f, []tasks.Arg{})
+	assert.NoError(t, err)
+	taskResults, err := task.Call()
+	assert.NoError(t, err)
+	assert.Equal(t, "float64", taskResults[0].Type)
+	assert.Equal(t, math.Pi, taskResults[0].Value)
+}
+
+func TestTaskCallWithSignitureInContext(t *testing.T) {
+	t.Parallel()
+
+	f := func(c context.Context) (interface{}, error) {
+		assert.NotNil(t, c)
+		signature := tasks.SignatureFromContext(c)
+		assert.NotNil(t, signature)
+		assert.Equal(t, "foo", signature.Name)
+		return math.Pi, nil
+	}
+	signature, err := tasks.NewSignature("foo", []tasks.Arg{})
+	assert.NoError(t, err)
+	task, err := tasks.NewWithSignature(f, signature)
 	assert.NoError(t, err)
 	taskResults, err := task.Call()
 	assert.NoError(t, err)

--- a/v1/tasks/task_test.go
+++ b/v1/tasks/task_test.go
@@ -108,7 +108,7 @@ func TestTaskCallWithContext(t *testing.T) {
 	assert.Equal(t, math.Pi, taskResults[0].Value)
 }
 
-func TestTaskCallWithSignitureInContext(t *testing.T) {
+func TestTaskCallWithSignatureInContext(t *testing.T) {
 	t.Parallel()
 
 	f := func(c context.Context) (interface{}, error) {

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -135,7 +135,7 @@ func (worker *Worker) Process(signature *tasks.Signature) error {
 	}
 
 	// Prepare task for processing
-	task, err := tasks.New(taskFunc, signature.Args)
+	task, err := tasks.NewWithSignature(taskFunc, signature)
 	// if this failed, it means the task is malformed, probably has invalid
 	// signature, go directly to task failed without checking whether to retry
 	if err != nil {


### PR DESCRIPTION
Rationale behind this PR:

I want to:

1. able to interrupt/cancel a running job.
2. running job able to send progress

both of these require the job func to know the task id so that I can save status to a db. e.g. Redis

I could make it an argument in the task function and send the task id on `Send`, but I reckon having the signature in the context make more sense.

See example: https://github.com/jackielii/process