### PR TITLE
Redis backend/broker performance and data race fixes

### DIFF
--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -92,8 +92,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 			// A way to stop this goroutine from b.StopConsuming
 			case <-b.stopReceivingChan:
 				return
-			default:
-				<-pool
+			case <-pool:
 				task, _ := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
 				//TODO: should this error be ignored?
 				if len(task) > 0 {

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -28,14 +28,16 @@ type Broker struct {
 	password          string
 	db                int
 	pool              *redis.Pool
+	poolOnce          sync.Once
 	stopReceivingChan chan int
 	stopDelayedChan   chan int
 	processingWG      sync.WaitGroup // use wait group to make sure task processing completes on interrupt signal
 	receivingWG       sync.WaitGroup
 	delayedWG         sync.WaitGroup
 	// If set, path to a socket file overrides hostname
-	socketPath string
-	redsync    *redsync.Redsync
+	socketPath  string
+	redsync     *redsync.Redsync
+	redsyncOnce sync.Once
 }
 
 // New creates new Broker instance
@@ -53,10 +55,8 @@ func New(cnf *config.Config, host, password, socketPath string, db int) iface.Br
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)
 
-	b.pool = nil
 	conn := b.open()
 	defer conn.Close()
-	defer b.pool.Close()
 
 	// Ping the server to make sure connection is live
 	_, err := conn.Do("PING")
@@ -72,28 +72,15 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	b.delayedWG.Add(1)
 
 	// Channel to which we will push tasks ready for processing by worker
-	deliveries := make(chan []byte)
+	deliveries := make(chan []byte, concurrency)
 	pool := make(chan struct{}, concurrency)
 
 	// initialize worker pool with maxWorkers workers
-	go func() {
-		for i := 0; i < concurrency; i++ {
-			pool <- struct{}{}
-		}
-	}()
-
-	// Helper function to return true if parallel task processing slots still available,
-	// false when we are already executing maximum allowed concurrent tasks
-	var concurrencyAvailable = func() bool {
-		return concurrency == 0 || (len(pool)-len(deliveries) > 0)
+	for i := 0; i < concurrency; i++ {
+		pool <- struct{}{}
 	}
 
-	// Timer is added otherwise when the pools were all active it will spin the for loop
-	var (
-		timerDuration = time.Duration(100000000 * time.Nanosecond) // 100 miliseconds
-		timer         = time.NewTimer(0)
-	)
-	// A receivig goroutine keeps popping messages from the queue by BLPOP
+	// A receiving goroutine keeps popping messages from the queue by BLPOP
 	// If the message is valid and can be unmarshaled into a proper structure
 	// we send it to the deliveries channel
 	go func() {
@@ -106,26 +93,15 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 			// A way to stop this goroutine from b.StopConsuming
 			case <-b.stopReceivingChan:
 				return
-			case <-timer.C:
-				// If concurrency is limited, limit the tasks being pulled off the queue
-				// until a pool is available
-				if concurrencyAvailable() {
-					task, err := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
-					if err != nil {
-						// something went wrong, wait a bit before continuing the loop
-						timer.Reset(timerDuration)
-						continue
-					}
-
+			default:
+				<-pool
+				task, _ := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
+				//TODO: should this error be ignored?
+				if len(task) > 0 {
 					deliveries <- task
 				}
-				if concurrencyAvailable() {
-					// parallel task processing slots still available, continue loop immediately
-					timer.Reset(0)
-				} else {
-					// using all parallel task processing slots, wait a bit before continuing the loop
-					timer.Reset(timerDuration)
-				}
+
+				pool <- struct{}{}
 			}
 		}
 	}()
@@ -186,6 +162,10 @@ func (b *Broker) StopConsuming() {
 
 	// Waiting for any tasks being processed to finish
 	b.processingWG.Wait()
+
+	if b.pool != nil {
+		b.pool.Close()
+	}
 }
 
 // Publish places a new message on the default queue
@@ -257,14 +237,9 @@ func (b *Broker) consume(deliveries <-chan []byte, pool chan struct{}, concurren
 		case err := <-errorsChan:
 			return err
 		case d := <-deliveries:
-			if concurrency > 0 {
-				// get worker from pool (blocks until one is available)
-				<-pool
-			}
-
 			b.processingWG.Add(1)
 
-			// Consume the task inside a gotourine so multiple tasks
+			// Consume the task inside a goroutine so multiple tasks
 			// can be processed concurrently
 			go func() {
 				if err := b.consumeOne(d, taskProcessor); err != nil {
@@ -272,11 +247,6 @@ func (b *Broker) consume(deliveries <-chan []byte, pool chan struct{}, concurren
 				}
 
 				b.processingWG.Done()
-
-				if concurrency > 0 {
-					// give worker back to pool
-					pool <- struct{}{}
-				}
 			}()
 		case <-b.Broker.GetStopChan():
 			return nil
@@ -313,7 +283,7 @@ func (b *Broker) nextTask(queue string) (result []byte, err error) {
 	conn := b.open()
 	defer conn.Close()
 
-	items, err := redis.ByteSlices(conn.Do("BLPOP", queue, 1))
+	items, err := redis.ByteSlices(conn.Do("BLPOP", queue, 1000))
 	if err != nil {
 		return []byte{}, err
 	}
@@ -348,9 +318,14 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 		reply interface{}
 	)
 
-	var pollPeriod = 20 // default poll period for delayed tasks
+	var pollPeriod = 500 // default poll period for delayed tasks
 	if b.GetConfig().Redis != nil {
-		pollPeriod = b.GetConfig().Redis.DelayedTasksPollPeriod
+		configuredPollPeriod := b.GetConfig().Redis.DelayedTasksPollPeriod
+		// the default period is 0, which bombards redis with requests, despite
+		// our intention of doing the opposite
+		if configuredPollPeriod > 0 {
+			pollPeriod = configuredPollPeriod
+		}
 	}
 
 	for {
@@ -381,8 +356,8 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 			return
 		}
 
-		conn.Send("MULTI")
-		conn.Send("ZREM", key, items[0])
+		_ = conn.Send("MULTI")
+		_ = conn.Send("ZREM", key, items[0])
 		reply, err = conn.Do("EXEC")
 		if err != nil {
 			return
@@ -399,13 +374,14 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 
 // open returns or creates instance of Redis connection
 func (b *Broker) open() redis.Conn {
-	if b.pool == nil {
+	b.poolOnce.Do(func() {
 		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
-	}
-	if b.redsync == nil {
-		var pools = []redsync.Pool{b.pool}
-		b.redsync = redsync.New(pools)
-	}
+	})
+
+	b.redsyncOnce.Do(func() {
+		b.redsync = redsync.New([]redsync.Pool{b.pool})
+	})
+
 	return b.pool.Get()
 }
 

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -52,6 +52,10 @@ func New(cnf *config.Config, host, password, socketPath string, db int) iface.Br
 
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)
 
 	conn := b.open()


### PR DESCRIPTION
This PR fixes a few things:

1. The broker and backend's `open` function was not thread safe and since the `pool` and `redsync` instance were initialized only once I wrapped them in a `sync.Once`
2. The timer in the broker's `StartConsuming` method often slept for either 0 or 100 milliseconds which first of all adds a strain to the Go scheduler. After every timer tick the broker would send a `BLPOP` to Redis with a timeout of 1 millisecond and if it doesn't find an item it would wait another 100 milliseconds and do the same. There's no point in doing this constant back and forth which eats up the server runinng machinery's CPU and Networking resources as well as Redis'. Instead, now we launch X amount of `BLPOP` operations with a timeout of 1 second, where X is the configured concurrency. This allows us to patiently wait for values from the Redis list and exit within 1 second, should the application receive a termination signal. The minimal concurrency is now set to 1, not sure if the `StartConsuming` method is the best place to check for that.
3. inside the `nextDelayedTask ` method of the broker the default value for the `DelayedTasksPollPeriod` would be 0, which cause us to sleep for 0 milliseconds and literally bombard Redis with queries. Now the default period is set to 500 with the inability to set it to 0, the lowest a user can get is 1 by configuring it manually, which shouldn't happen anyways.

As a result CPU usage on our containers running machinery with Redis broker and Redis backend dropped about 15 times.