### PR TITLE
Support for using non-AMQP as broker and AMQP as result backend

### DIFF
--- a/integration-tests/sqs_amqp_test.go
+++ b/integration-tests/sqs_amqp_test.go
@@ -1,0 +1,37 @@
+package integration_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/RichardKnop/machinery/v1/config"
+)
+
+func TestSQSAmqp(t *testing.T) {
+	sqsURL := os.Getenv("SQS_URL")
+	if sqsURL == "" {
+		t.Skip("SQS_URL is not defined")
+	}
+
+	amqpURL := os.Getenv("AMQP_URL")
+	if amqpURL == "" {
+		t.Skip("AMQP_URL is not defined")
+	}
+
+	// AMQP broker, AMQP result backend
+	server := testSetup(&config.Config{
+		Broker:        sqsURL,
+		DefaultQueue:  "test_queue",
+		ResultBackend: amqpURL,
+		AMQP: &config.AMQPConfig{
+			Exchange:      "test_exchange",
+			ExchangeType:  "direct",
+			BindingKey:    "test_task",
+			PrefetchCount: 1,
+		},
+	})
+	worker := server.NewWorker("test_worker", 0)
+	go worker.Launch()
+	testAll(server, t)
+	worker.Quit()
+}

--- a/v1/backends/amqp/amqp.go
+++ b/v1/backends/amqp/amqp.go
@@ -48,7 +48,7 @@ func (b *Backend) InitGroup(groupUUID string, taskUUIDs []string) error {
 // NOTE: Given AMQP limitation this will only return true if all finished
 // tasks were successful as we do not keep track of completed failed tasks
 func (b *Backend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, error) {
-	conn, channel, err := b.Open(b.GetConfig().Broker, b.GetConfig().TLSConfig)
+	conn, channel, err := b.Open(b.GetConfig().ResultBackend, b.GetConfig().TLSConfig)
 	if err != nil {
 		return false, err
 	}
@@ -64,7 +64,7 @@ func (b *Backend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, er
 
 // GroupTaskStates returns states of all tasks in the group
 func (b *Backend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
-	conn, channel, err := b.Open(b.GetConfig().Broker, b.GetConfig().TLSConfig)
+	conn, channel, err := b.Open(b.GetConfig().ResultBackend, b.GetConfig().TLSConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (b *Backend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*task
 // whether the worker should trigger chord (true) or no if it has been triggered
 // already (false)
 func (b *Backend) TriggerChord(groupUUID string) (bool, error) {
-	conn, channel, err := b.Open(b.GetConfig().Broker, b.GetConfig().TLSConfig)
+	conn, channel, err := b.Open(b.GetConfig().ResultBackend, b.GetConfig().TLSConfig)
 	if err != nil {
 		return false, err
 	}
@@ -196,7 +196,7 @@ func (b *Backend) GetState(taskUUID string) (*tasks.TaskState, error) {
 		"x-expires": int32(b.getExpiresIn()),
 	}
 	conn, channel, _, _, _, err := b.Connect(
-		b.GetConfig().Broker,
+		b.GetConfig().ResultBackend,
 		b.GetConfig().TLSConfig,
 		b.GetConfig().AMQP.Exchange,     // exchange name
 		b.GetConfig().AMQP.ExchangeType, // exchange type
@@ -240,7 +240,7 @@ func (b *Backend) GetState(taskUUID string) (*tasks.TaskState, error) {
 
 // PurgeState deletes stored task state
 func (b *Backend) PurgeState(taskUUID string) error {
-	conn, channel, err := b.Open(b.GetConfig().Broker, b.GetConfig().TLSConfig)
+	conn, channel, err := b.Open(b.GetConfig().ResultBackend, b.GetConfig().TLSConfig)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (b *Backend) PurgeState(taskUUID string) error {
 
 // PurgeGroupMeta deletes stored group meta data
 func (b *Backend) PurgeGroupMeta(groupUUID string) error {
-	conn, channel, err := b.Open(b.GetConfig().Broker, b.GetConfig().TLSConfig)
+	conn, channel, err := b.Open(b.GetConfig().ResultBackend, b.GetConfig().TLSConfig)
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func (b *Backend) updateState(taskState *tasks.TaskState) error {
 		"x-expires": int32(b.getExpiresIn()),
 	}
 	conn, channel, queue, confirmsChan, _, err := b.Connect(
-		b.GetConfig().Broker,
+		b.GetConfig().ResultBackend,
 		b.GetConfig().TLSConfig,
 		b.GetConfig().AMQP.Exchange,     // exchange name
 		b.GetConfig().AMQP.ExchangeType, // exchange type
@@ -348,7 +348,7 @@ func (b *Backend) markTaskCompleted(signature *tasks.Signature, taskState *tasks
 		"x-expires": int32(b.getExpiresIn()),
 	}
 	conn, channel, queue, confirmsChan, _, err := b.Connect(
-		b.GetConfig().Broker,
+		b.GetConfig().ResultBackend,
 		b.GetConfig().TLSConfig,
 		b.GetConfig().AMQP.Exchange,     // exchange name
 		b.GetConfig().AMQP.ExchangeType, // exchange type

--- a/v1/backends/amqp/amqp_test.go
+++ b/v1/backends/amqp/amqp_test.go
@@ -21,10 +21,15 @@ func init() {
 		return
 	}
 
+	amqp2URL := os.Getenv("AMQP2_URL")
+	if amqp2URL == "" {
+		amqp2URL = amqpURL
+	}
+
 	amqpConfig = &config.Config{
 		Broker:        amqpURL,
 		DefaultQueue:  "test_queue",
-		ResultBackend: amqpURL,
+		ResultBackend: amqp2URL,
 		AMQP: &config.AMQPConfig{
 			Exchange:      "test_exchange",
 			ExchangeType:  "direct",


### PR DESCRIPTION
The AMQP backend should choose correct URL to connect to.

For now some cases should not work.
E.g., Use SQS as broker and AMQP as result backend.
