### PR TITLE
Apply binding to default queue

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -199,7 +199,8 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 		}
 	}
 
-	connection, err := b.GetOrOpenConnection(signature.RoutingKey,
+	connection, err := b.GetOrOpenConnection(
+		b.GetConfig().DefaultQueue,
 		b.GetConfig().AMQP.BindingKey, // queue binding key
 		nil,                           // exchange declare args
 		nil,                           // queue declare args


### PR DESCRIPTION
Before this pr, the routing key was bound to the default binding key.
This resulted in spurious bindings being created.

This pr changes the call to GetOrOpenConnection to use the defaultqueue vs the routing key as a queue to lookup and bind.
Note that it doesn't seem like this queue element isn't used by this code at all, so correctness of the rest of the funciton is preserved.
Because we bind the default queue to the default binding key, we also prevent any other unintentional behaviour (as the integrity of the maintained connections is not broken)
