### PR TITLE
use routing key as both queue name and binding key

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -199,11 +199,18 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 		}
 	}
 
+	queue := b.GetConfig().DefaultQueue
+	bindingKey := b.GetConfig().AMQP.BindingKey // queue binding key
+	if b.isDirectExchange() {
+		queue = signature.RoutingKey
+		bindingKey = signature.RoutingKey
+	}
+
 	connection, err := b.GetOrOpenConnection(
-		b.GetConfig().DefaultQueue,
-		b.GetConfig().AMQP.BindingKey, // queue binding key
-		nil,                           // exchange declare args
-		nil,                           // queue declare args
+		queue,
+		bindingKey, // queue binding key
+		nil,        // exchange declare args
+		nil,        // queue declare args
 		amqp.Table(b.GetConfig().AMQP.QueueBindingArgs), // queue binding args
 	)
 	if err != nil {

--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -390,6 +390,10 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 	return nil
 }
 
+func (b *Broker) isDirectExchange() bool {
+	return b.GetConfig().AMQP != nil && b.GetConfig().AMQP.ExchangeType == "direct"
+}
+
 // AdjustRoutingKey makes sure the routing key is correct.
 // If the routing key is an empty string:
 // a) set it to binding key for direct exchange type
@@ -399,7 +403,7 @@ func (b *Broker) AdjustRoutingKey(s *tasks.Signature) {
 		return
 	}
 
-	if b.GetConfig().AMQP != nil && b.GetConfig().AMQP.ExchangeType == "direct" {
+	if b.isDirectExchange() {
 		// The routing algorithm behind a direct exchange is simple - a message goes
 		// to the queues whose binding key exactly matches the routing key of the message.
 		s.RoutingKey = b.GetConfig().AMQP.BindingKey


### PR DESCRIPTION
As discussed in #419 , before this PR, it is unable to setup a new queue binded to the direct exchange with a expected binding key.

For non direct type exchange, it acts exactly as before.
For direct type exchange:
  1. If no routing key set in the signature, `AdjustRoutingKey` sets it to `b.GetConfig().AMQP.BindingKey`, in this PR, `bindingKey = signature.RoutingKey` ensures that it behaves like `bindingKey = b.GetConfig().AMQP.BindingKey`;
  2. For cases that routing key is set in the signature, it always use passed routing key as binding key, so every queue will have a independent binding to the exchange and it matches the routing key exactly.
  So I believe this PR preserves the correctness of rest code.
