### PR TITLE
Limit Redis broker task execution concurrency by config too + fix shutdown panic

### DIFF
--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -96,11 +96,8 @@ func (b *Broker) StopConsuming() {
 	default:
 	}
 	// Notifying the stop channel stops consuming of messages
-	select {
-	case b.stopChan <- 1:
-		log.WARNING.Print("Stop channel")
-	default:
-	}
+	close(b.stopChan)
+	log.WARNING.Print("Stop channel")
 }
 
 // GetRegisteredTaskNames returns registered tasks names

--- a/v1/common/broker_test.go
+++ b/v1/common/broker_test.go
@@ -70,10 +70,5 @@ func TestStopConsuming(t *testing.T) {
 		default:
 			assert.Fail(t, "still blocking")
 		}
-		select {
-		case <-broker.GetRetryStopChan():
-		default:
-			assert.Fail(t, "still blocking")
-		}
 	})
 }

--- a/v1/common/broker_test.go
+++ b/v1/common/broker_test.go
@@ -3,6 +3,7 @@ package common_test
 import (
 	"testing"
 
+	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/common"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
@@ -62,6 +63,7 @@ func TestStopConsuming(t *testing.T) {
 		broker := common.NewBroker(&config.Config{
 			DefaultQueue: "queue",
 		})
+		broker.StartConsuming("", 1, &machinery.Worker{})
 		broker.StopConsuming()
 		select {
 		case <-broker.GetStopChan():

--- a/v1/common/broker_test.go
+++ b/v1/common/broker_test.go
@@ -54,3 +54,24 @@ func TestGetRegisteredTaskNames(t *testing.T) {
 	broker.SetRegisteredTaskNames(fooTasks)
 	assert.Equal(t, fooTasks, broker.GetRegisteredTaskNames())
 }
+
+func TestStopConsuming(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stop consuming", func(t *testing.T) {
+		broker := common.NewBroker(&config.Config{
+			DefaultQueue: "queue",
+		})
+		broker.StopConsuming()
+		select {
+		case <-broker.GetStopChan():
+		default:
+			assert.Fail(t, "still blocking")
+		}
+		select {
+		case <-broker.GetRetryStopChan():
+		default:
+			assert.Fail(t, "still blocking")
+		}
+	})
+}


### PR DESCRIPTION
Done same way it is done in AMPQ broker here - https://github.com/RichardKnop/machinery/blob/master/v1/brokers/amqp/amqp.go#L261 
Now Redis broker applies Worker concurrency param only to consumption from Redis, not to task execution, every task just gets it's own goroutine without limit which leads to unbounded growth of tasks Worker is executing if single task is considerably heavier than consumption from Redis.

Changed that so that only Worker.Concurrency number of tasks can be executed at a time.