### PR TITLE
AMQPConfig AutoDelete 

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -367,7 +367,7 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 		b.GetConfig().AMQP.ExchangeType, // exchange type
 		queueName,                       // queue name
 		true,                            // queue durable
-		false,                           // queue delete when unused
+		b.GetConfig().AMQP.AutoDelete,                           // queue delete when unused
 		queueName,                       // queue binding key
 		nil,                             // exchange declare args
 		declareQueueArgs,                // queue declare args

--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -367,7 +367,7 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 		b.GetConfig().AMQP.ExchangeType, // exchange type
 		queueName,                       // queue name
 		true,                            // queue durable
-		b.GetConfig().AMQP.AutoDelete,                           // queue delete when unused
+		b.GetConfig().AMQP.AutoDelete,   // queue delete when unused
 		queueName,                       // queue binding key
 		nil,                             // exchange declare args
 		declareQueueArgs,                // queue declare args

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -77,6 +77,8 @@ type AMQPConfig struct {
 	QueueBindingArgs QueueBindingArgs `yaml:"queue_binding_args" envconfig:"AMQP_QUEUE_BINDING_ARGS"`
 	BindingKey       string           `yaml:"binding_key" envconfig:"AMQP_BINDING_KEY"`
 	PrefetchCount    int              `yaml:"prefetch_count" envconfig:"AMQP_PREFETCH_COUNT"`
+	AutoDelete		 bool			  `yaml:"auto_delete" envconfig:"AMQP_AUTO_DELETE"`
+
 }
 
 // DynamoDBConfig wraps DynamoDB related configuration

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -77,8 +77,7 @@ type AMQPConfig struct {
 	QueueBindingArgs QueueBindingArgs `yaml:"queue_binding_args" envconfig:"AMQP_QUEUE_BINDING_ARGS"`
 	BindingKey       string           `yaml:"binding_key" envconfig:"AMQP_BINDING_KEY"`
 	PrefetchCount    int              `yaml:"prefetch_count" envconfig:"AMQP_PREFETCH_COUNT"`
-	AutoDelete		 bool			  `yaml:"auto_delete" envconfig:"AMQP_AUTO_DELETE"`
-
+	AutoDelete       bool             `yaml:"auto_delete" envconfig:"AMQP_AUTO_DELETE"`
 }
 
 // DynamoDBConfig wraps DynamoDB related configuration


### PR DESCRIPTION
As discussed in #425 , before this PR, it is impossible to set the autodelete param of delayed queues.

If nobody sets this value to `true`, it acts exactly as before.
