### PR TITLE
Fix pubsub termination

### DIFF
--- a/v1/brokers/gcppubsub/gcp_pubsub.go
+++ b/v1/brokers/gcppubsub/gcp_pubsub.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -25,12 +23,12 @@ type Broker struct {
 	subscriptionName string
 	MaxExtension     time.Duration
 
-	processingWG sync.WaitGroup
+	stopDone chan struct{}
 }
 
 // New creates new Broker instance
 func New(cnf *config.Config, projectID, subscriptionName string) (iface.Broker, error) {
-	b := &Broker{Broker: common.NewBroker(cnf)}
+	b := &Broker{Broker: common.NewBroker(cnf), stopDone: make(chan struct{})}
 	b.subscriptionName = subscriptionName
 
 	ctx := context.Background()
@@ -86,41 +84,35 @@ func New(cnf *config.Config, projectID, subscriptionName string) (iface.Broker, 
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)
-	deliveries := make(chan *pubsub.Message)
 
 	sub := b.service.Subscription(b.subscriptionName)
 
 	if b.MaxExtension != 0 {
 		sub.ReceiveSettings.MaxExtension = b.MaxExtension
-		sub.ReceiveSettings.NumGoroutines = concurrency
 	}
+
+	sub.ReceiveSettings.NumGoroutines = concurrency
+	log.INFO.Print("[*] Waiting for messages. To exit press CTRL+C")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		log.INFO.Print("[*] Waiting for messages. To exit press CTRL+C")
-
-		for {
-			select {
-			// A way to stop this goroutine from b.StopConsuming
-			case <-b.GetStopChan():
-				cancel()
-				return
-			default:
-				err := sub.Receive(ctx, func(_ctx context.Context, msg *pubsub.Message) {
-					deliveries <- msg
-				})
-
-				if err != nil {
-					log.ERROR.Printf("Error when receiving messages. Error: %v", err)
-					continue
-				}
-			}
-		}
+		<-b.GetStopChan()
+		cancel()
 	}()
 
-	if err := b.consume(deliveries, concurrency, taskProcessor); err != nil {
-		return b.GetRetry(), err
+	for {
+		err := sub.Receive(ctx, func(_ctx context.Context, msg *pubsub.Message) {
+			b.consumeOne(msg, taskProcessor)
+		})
+		if err == nil {
+			break
+		}
+
+		log.ERROR.Printf("Error when receiving messages. Error: %v", err)
+		continue
 	}
+
+	close(b.stopDone)
 
 	return b.GetRetry(), nil
 }
@@ -130,7 +122,7 @@ func (b *Broker) StopConsuming() {
 	b.Broker.StopConsuming()
 
 	// Waiting for any tasks being processed to finish
-	b.processingWG.Wait()
+	<-b.stopDone
 }
 
 // Publish places a new message on the default queue
@@ -171,58 +163,11 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	return nil
 }
 
-// consume takes delivered messages from the channel and manages a worker pool
-// to process tasks concurrently
-func (b *Broker) consume(deliveries <-chan *pubsub.Message, concurrency int, taskProcessor iface.TaskProcessor) error {
-	pool := make(chan struct{}, concurrency)
-
-	// initialize worker pool with maxWorkers workers
-	go func() {
-		for i := 0; i < concurrency; i++ {
-			pool <- struct{}{}
-		}
-	}()
-
-	errorsChan := make(chan error)
-
-	for {
-		select {
-		case err := <-errorsChan:
-			return err
-		case d := <-deliveries:
-			if concurrency > 0 {
-				// get worker from pool (blocks until one is available)
-				<-pool
-			}
-
-			b.processingWG.Add(1)
-
-			// Consume the task inside a gotourine so multiple tasks
-			// can be processed concurrently
-			go func() {
-				if err := b.consumeOne(d, taskProcessor); err != nil {
-					errorsChan <- err
-				}
-
-				b.processingWG.Done()
-
-				if concurrency > 0 {
-					// give worker back to pool
-					pool <- struct{}{}
-				}
-			}()
-		case <-b.GetStopChan():
-			return nil
-		}
-	}
-}
-
 // consumeOne processes a single message using TaskProcessor
-func (b *Broker) consumeOne(delivery *pubsub.Message, taskProcessor iface.TaskProcessor) error {
+func (b *Broker) consumeOne(delivery *pubsub.Message, taskProcessor iface.TaskProcessor) {
 	if len(delivery.Data) == 0 {
 		delivery.Nack()
 		log.ERROR.Printf("received an empty message, the delivery was %v", delivery)
-		return errors.New("Received an empty message")
 	}
 
 	sig := new(tasks.Signature)
@@ -231,24 +176,21 @@ func (b *Broker) consumeOne(delivery *pubsub.Message, taskProcessor iface.TaskPr
 	if err := decoder.Decode(sig); err != nil {
 		delivery.Nack()
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
-		return err
 	}
 
 	// If the task is not registered return an error
 	// and leave the message in the queue
 	if !b.IsTaskRegistered(sig.Name) {
 		delivery.Nack()
-		return fmt.Errorf("task %s is not registered", sig.Name)
+		log.ERROR.Printf("task %s is not registered", sig.Name)
 	}
 
 	err := taskProcessor.Process(sig)
 	if err != nil {
 		delivery.Nack()
-		return err
+		log.ERROR.Printf("Failed process of task", err)
 	}
 
 	// Call Ack() after successfully consuming and processing the message
 	delivery.Ack()
-
-	return err
 }


### PR DESCRIPTION
Pubsub was not terminating correclty when SIGTERM was received. It was exiting as soon as it was received.

Pubsub docs say that its best practise to also run any processing code in the Receive function, has been refactored to take that into account