### PR TITLE
Re:433 Expose SQS ReceiptHandle in task signature

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -216,6 +216,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
 		return err
 	}
+	sig.SQSReceiptHandle = *delivery.Messages[0].ReceiptHandle
 
 	// If the task is not registered return an error
 	// and leave the message in the queue

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -59,6 +59,8 @@ type Signature struct {
 	ChordCallback  *Signature
 	//MessageGroupId for Broker, e.g. SQS
 	BrokerMessageGroupId string
+	//ReceiptHandle of SQS Message
+	SQSReceiptHandle string
 }
 
 // NewSignature creates a new task signature


### PR DESCRIPTION
Fixes #433 

When using SQS broker there is no way to get hold of SQS message's ReceiptHandle, this PR adds a new property `SQSReceiptHandle` to `tasks.Signature` which gets populated by SQS broker when consuming a message