### PR TITLE
Fix issue with SQS broker, where it receives more messages than it can consume at a given time

### DIFF
--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -126,8 +126,8 @@ func init() {
 	}
 }
 
-func (b *Broker) ConsumeForTest(deliveries <-chan *awssqs.ReceiveMessageOutput, concurrency int, taskProcessor iface.TaskProcessor) error {
-	return b.consume(deliveries, concurrency, taskProcessor)
+func (b *Broker) ConsumeForTest(deliveries <-chan *awssqs.ReceiveMessageOutput, concurrency int, taskProcessor iface.TaskProcessor, pool chan struct{}) error {
+	return b.consume(deliveries, concurrency, taskProcessor, pool)
 }
 
 func (b *Broker) ConsumeOneForTest(delivery *awssqs.ReceiveMessageOutput, taskProcessor iface.TaskProcessor) error {
@@ -185,7 +185,6 @@ func (b *Broker) GetRetryStopChanForTest() chan int {
 func (b *Broker) GetQueueURLForTest(taskProcessor iface.TaskProcessor) *string {
 	return b.getQueueURL(taskProcessor)
 }
-
 
 func (b *Broker) GetCustomQueueURL(customQueue string) *string {
 	return aws.String(b.GetConfig().Broker + "/" + customQueue)

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -87,6 +87,7 @@ func TestPrivateFunc_consume(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	pool := make(chan struct{}, 0)
 	wk := server1.NewWorker("sms_worker", 0)
 	deliveries := make(chan *awssqs.ReceiveMessageOutput)
 	outputCopy := *receiveMessageOutput
@@ -94,7 +95,7 @@ func TestPrivateFunc_consume(t *testing.T) {
 	go func() { deliveries <- &outputCopy }()
 
 	// an infinite loop will be executed only when there is no error
-	err = testAWSSQSBroker.ConsumeForTest(deliveries, 0, wk)
+	err = testAWSSQSBroker.ConsumeForTest(deliveries, 0, wk, pool)
 	assert.NotNil(t, err)
 
 }
@@ -229,7 +230,6 @@ func TestPrivateFunc_deleteOne(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-
 func Test_CustomQueueName(t *testing.T) {
 	server1, err := machinery.NewServer(cnf)
 	if err != nil {
@@ -239,7 +239,6 @@ func Test_CustomQueueName(t *testing.T) {
 	wk := server1.NewWorker("test-worker", 0)
 	qURL := testAWSSQSBroker.GetQueueURLForTest(wk)
 	assert.Equal(t, qURL, testAWSSQSBroker.DefaultQueueURLForTest(), "")
-
 
 	wk2 := server1.NewCustomQueueWorker("test-worker", 0, "my-custom-queue")
 	qURL2 := testAWSSQSBroker.GetQueueURLForTest(wk2)

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -298,6 +298,4 @@ func TestPrivateFunc_consumeWithConcurrency(t *testing.T) {
 		// call timed out
 		t.Fatal("task not processed in 2 seconds")
 	}
-	//assert.Equal(t, testResp, resp)
-
 }


### PR DESCRIPTION
Fixes an issue with SQS Broker where it receives more messages than concurrency specified, because of the fact that while receiving it was not checking whether already received job is done or not, instead it fetches next task as soon as task is assigned to a worker goroutine, this causes Machinery to move more messages into "Inflight" in SQS than the concurrency specified. 

E.g. Before fix if worker is started with concurrency of 1, Machinery will receive two messages from SQS ( one after other) but since concurrency is 1 will only be processing one message at a time.