### PR TITLE
fix redis broker quit very slow

### DIFF
--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -36,7 +36,7 @@ func TestRedisRedis_NormalTasksPollPeriod(t *testing.T) {
 		t.Skip("REDIS_URL is not defined")
 	}
 
-	normalTasksPollPeriod := 5
+	normalTasksPollPeriod := 1
 
 	// Redis broker, Redis result backend
 	var server = testSetup(&config.Config{
@@ -57,7 +57,7 @@ func TestRedisRedis_NormalTasksPollPeriod(t *testing.T) {
 	errorChan := make(chan error)
 	worker.LaunchAsync(errorChan)
 
-	testAll(server, t)
+	testSendTask(server, t)
 
 	before := time.Now()
 	worker.Quit()

--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -2,8 +2,12 @@ package integration_test
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/RichardKnop/machinery/v1/config"
 )
@@ -24,4 +28,44 @@ func TestRedisRedis(t *testing.T) {
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()
+}
+
+func TestRedisRedis_NormalTasksPollPeriod(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skip("REDIS_URL is not defined")
+	}
+
+	normalTasksPollPeriod := 5
+
+	// Redis broker, Redis result backend
+	var server = testSetup(&config.Config{
+		Broker:        fmt.Sprintf("redis://%v", redisURL),
+		DefaultQueue:  "test_queue",
+		ResultBackend: fmt.Sprintf("redis://%v", redisURL),
+		Redis: &config.RedisConfig{
+			MaxIdle:                3,
+			IdleTimeout:            240,
+			ReadTimeout:            15,
+			WriteTimeout:           15,
+			ConnectTimeout:         15,
+			DelayedTasksPollPeriod: 20,
+			NormalTasksPollPeriod:  normalTasksPollPeriod, // Affected by ReadTimeout
+		},
+	})
+	worker := server.NewWorker("test_worker", 0)
+	errorChan := make(chan error)
+	worker.LaunchAsync(errorChan)
+
+	testAll(server, t)
+
+	before := time.Now()
+	worker.Quit()
+	after := time.Now()
+
+	d := after.Sub(before)
+	b := math.Ceil(d.Seconds())
+
+	// Including other time, so round up
+	assert.Equal(t, b, float64(normalTasksPollPeriod+1))
 }

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -283,7 +283,12 @@ func (b *Broker) nextTask(queue string) (result []byte, err error) {
 	conn := b.open()
 	defer conn.Close()
 
-	items, err := redis.ByteSlices(conn.Do("BLPOP", queue, b.GetConfig().Redis.NormalTasksPollPeriod))
+	normalTasksPollPeriod := 1000
+	if b.GetConfig().Redis != nil && b.GetConfig().Redis.NormalTasksPollPeriod != 0 {
+		normalTasksPollPeriod = b.GetConfig().Redis.NormalTasksPollPeriod
+	}
+
+	items, err := redis.ByteSlices(conn.Do("BLPOP", queue, normalTasksPollPeriod))
 	if err != nil {
 		return []byte{}, err
 	}

--- a/v1/common/redis.go
+++ b/v1/common/redis.go
@@ -16,6 +16,7 @@ var (
 		WriteTimeout:           15,
 		ConnectTimeout:         15,
 		DelayedTasksPollPeriod: 20,
+		NormalTasksPollPeriod:  15, // Affected by ReadTimeout
 	}
 )
 

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -126,6 +126,9 @@ type RedisConfig struct {
 
 	// DelayedTasksPollPeriod specifies the period in milliseconds when polling redis for delayed tasks
 	DelayedTasksPollPeriod int `yaml:"delayed_tasks_poll_period" envconfig:"REDIS_DELAYED_TASKS_POLL_PERIOD"`
+
+	// NormalTasksPollPeriod specifies the period in milliseconds when polling redis for normal tasks
+	NormalTasksPollPeriod int `yaml:"normal_tasks_poll_period" envconfig:"REDIS_NORMAL_TASKS_POLL_PERIOD"`
 }
 
 // GCPPubSubConfig wraps GCP PubSub related configuration

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -41,6 +41,7 @@ var (
 			WriteTimeout:           15,
 			ConnectTimeout:         15,
 			DelayedTasksPollPeriod: 20,
+			NormalTasksPollPeriod:  15,
 		},
 		GCPPubSub: &GCPPubSubConfig{
 			Client: nil,


### PR DESCRIPTION
#439
1. Use select default is more logical
2. Add NormalTasksPollPeriod param to control redis BLPOP timeout, depending on your business scenario choice suitable value.