### PR TITLE
Fix #439 race condition and slow shutdown with worker

### DIFF
--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 )
 
@@ -24,4 +26,73 @@ func TestRedisRedis(t *testing.T) {
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()
+}
+
+func TestRedisRedisWorkerQuitRaceCondition(t *testing.T) {
+	repeat := 3
+	for i := 0; i < repeat; i++ {
+		redisURL := os.Getenv("REDIS_URL")
+		if redisURL == "" {
+			t.Skip("REDIS_URL is not defined")
+		}
+
+		// Redis broker, Redis result backend
+		cnf := &config.Config{
+			Broker:        fmt.Sprintf("redis://%v", redisURL),
+			DefaultQueue:  "test_queue",
+			ResultBackend: fmt.Sprintf("redis://%v", redisURL),
+		}
+
+		server, _ := machinery.NewServer(cnf)
+		worker := server.NewWorker("test_worker", 0)
+
+		errorsChan := make(chan error, 1)
+
+		// Check Quit() immediately after LaunchAsync() will shutdown gracefully
+		// and not panic on close(b.stopChan)
+		worker.LaunchAsync(errorsChan)
+		worker.Quit()
+
+		if err := <-errorsChan; err != nil {
+			t.Errorf("Error shutting down machinery worker gracefully %+v", err)
+			continue
+		}
+	}
+}
+
+func TestRedisRedisWorkerQuickQuit(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skip("REDIS_URL is not defined")
+	}
+
+	// Redis broker, Redis result backend
+	pollPeriod := 1
+	cnf := &config.Config{
+		Broker:        fmt.Sprintf("redis://%v", redisURL),
+		DefaultQueue:  "test_queue",
+		ResultBackend: fmt.Sprintf("redis://%v", redisURL),
+		Redis: &config.RedisConfig{
+			NormalTasksPollPeriod: pollPeriod, // default: 1000
+		},
+	}
+
+	server, _ := machinery.NewServer(cnf)
+	worker := server.NewWorker("test_worker", 0)
+
+	errorsChan := make(chan error, 1)
+
+	// Check Quit() immediately after LaunchAsync() will shutdown gracefully
+	// and not panic
+	worker.LaunchAsync(errorsChan)
+
+	before := time.Now()
+	worker.Quit()
+	delta := time.Now().Sub(before)
+
+	threshold := time.Duration(pollPeriod)*time.Millisecond + 1000 // add 1 second as buffer
+
+	if delta.Nanoseconds() > threshold.Nanoseconds() {
+		t.Error("Worker quit() exceeded timeout")
+	}
 }

--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -22,7 +22,12 @@ type Broker struct {
 
 // NewBroker creates new Broker instance
 func NewBroker(cnf *config.Config) Broker {
-	return Broker{cnf: cnf, retry: true}
+	return Broker{
+		cnf:           cnf,
+		retry:         true,
+		stopChan:      make(chan int),
+		retryStopChan: make(chan int),
+	}
 }
 
 // GetConfig returns config
@@ -81,8 +86,6 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 		b.retryFunc = retry.Closure()
 	}
 
-	b.stopChan = make(chan int)
-	b.retryStopChan = make(chan int)
 }
 
 // StopConsuming is a common part of StopConsuming

--- a/v1/common/redis.go
+++ b/v1/common/redis.go
@@ -15,6 +15,7 @@ var (
 		ReadTimeout:            15,
 		WriteTimeout:           15,
 		ConnectTimeout:         15,
+		NormalTasksPollPeriod:  1000,
 		DelayedTasksPollPeriod: 20,
 	}
 )

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -40,6 +40,7 @@ var (
 			ReadTimeout:            15,
 			WriteTimeout:           15,
 			ConnectTimeout:         15,
+			NormalTasksPollPeriod:  1000,
 			DelayedTasksPollPeriod: 20,
 		},
 		GCPPubSub: &GCPPubSubConfig{
@@ -123,6 +124,9 @@ type RedisConfig struct {
 	// ConnectTimeout specifies the timeout in seconds for connecting to the Redis server when
 	// no DialNetDial option is specified.
 	ConnectTimeout int `yaml:"connect_timeout" envconfig:"REDIS_CONNECT_TIMEOUT"`
+
+	// NormalTasksPollPeriod specifies the period in milliseconds when polling redis for normal tasks
+	NormalTasksPollPeriod int `yaml:"normal_tasks_poll_period" envconfig:"REDIS_NORMAL_TASKS_POLL_PERIOD"`
 
 	// DelayedTasksPollPeriod specifies the period in milliseconds when polling redis for delayed tasks
 	DelayedTasksPollPeriod int `yaml:"delayed_tasks_poll_period" envconfig:"REDIS_DELAYED_TASKS_POLL_PERIOD"`

--- a/v1/factories_test.go
+++ b/v1/factories_test.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"unsafe"
 
 	machinery "github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/stretchr/testify/assert"
 
 	amqpbroker "github.com/RichardKnop/machinery/v1/brokers/amqp"
+	brokeriface "github.com/RichardKnop/machinery/v1/brokers/iface"
 	redisbroker "github.com/RichardKnop/machinery/v1/brokers/redis"
 	sqsbroker "github.com/RichardKnop/machinery/v1/brokers/sqs"
 
@@ -111,7 +113,7 @@ func TestBrokerFactory(t *testing.T) {
 		expected := amqpbroker.New(&cnf)
 		assert.True(
 			t,
-			reflect.DeepEqual(actual, expected),
+			brokerEqual(actual, expected),
 			fmt.Sprintf("conn = %v, want %v", actual, expected),
 		)
 	}
@@ -135,7 +137,7 @@ func TestBrokerFactory(t *testing.T) {
 		expected := redisbroker.New(&cnf, "localhost:6379", "password", "", 0)
 		assert.True(
 			t,
-			reflect.DeepEqual(actual, expected),
+			brokerEqual(actual, expected),
 			fmt.Sprintf("conn = %v, want %v", actual, expected),
 		)
 	}
@@ -157,7 +159,7 @@ func TestBrokerFactory(t *testing.T) {
 		expected := redisbroker.New(&cnf, "localhost:6379", "", "", 0)
 		assert.True(
 			t,
-			reflect.DeepEqual(actual, expected),
+			brokerEqual(actual, expected),
 			fmt.Sprintf("conn = %v, want %v", actual, expected),
 		)
 	}
@@ -179,7 +181,7 @@ func TestBrokerFactory(t *testing.T) {
 		expected := redisbroker.New(&cnf, "", "", "/tmp/redis.sock", 0)
 		assert.True(
 			t,
-			reflect.DeepEqual(actual, expected),
+			brokerEqual(actual, expected),
 			fmt.Sprintf("conn = %v, want %v", actual, expected),
 		)
 	}
@@ -219,6 +221,28 @@ func TestBrokerFactory(t *testing.T) {
 	}
 	os.Unsetenv("DISABLE_STRICT_SQS_CHECK")
 
+}
+
+func brokerEqual(x, y brokeriface.Broker) bool {
+	// unset Broker.stopChan and Broker.retryStopChan to nil before using
+	// reflect.DeepEqual() as the objects will have a different address
+	rx := reflect.ValueOf(x).Elem()
+	rxf := rx.FieldByName("stopChan")
+	rxf = reflect.NewAt(rxf.Type(), unsafe.Pointer(rxf.UnsafeAddr())).Elem()
+	rxf.Set(reflect.Zero(rxf.Type()))
+	rxf = rx.FieldByName("retryStopChan")
+	rxf = reflect.NewAt(rxf.Type(), unsafe.Pointer(rxf.UnsafeAddr())).Elem()
+	rxf.Set(reflect.Zero(rxf.Type()))
+
+	ry := reflect.ValueOf(y).Elem()
+	ryf := ry.FieldByName("stopChan")
+	ryf = reflect.NewAt(ryf.Type(), unsafe.Pointer(ryf.UnsafeAddr())).Elem()
+	ryf.Set(reflect.Zero(ryf.Type()))
+	ryf = ry.FieldByName("retryStopChan")
+	ryf = reflect.NewAt(ryf.Type(), unsafe.Pointer(ryf.UnsafeAddr())).Elem()
+	ryf.Set(reflect.Zero(ryf.Type()))
+
+	return reflect.DeepEqual(x, y)
 }
 
 func TestBrokerFactoryError(t *testing.T) {


### PR DESCRIPTION
Fix #439:
1. When launching Redis worker and then shutdown immediately, StopConsuming() could try to close(b.StopChan) BEFORE b.StopChan is initialized inside StartConsuming().
Solution: Initialize field when object is being initialized.

2. When using Redis broker, nextTaks() usings BLPOP can block for a long time.
Solution: Make timeout value configurable.

See also: PR #406, #443