### PR TITLE
Enhance error handling for a race condition in Redis broker

### DIFF
--- a/v1/brokers/errs/errors.go
+++ b/v1/brokers/errs/errors.go
@@ -1,6 +1,7 @@
 package errs
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -19,3 +20,6 @@ func (e ErrCouldNotUnmarshaTaskSignature) Error() string {
 func NewErrCouldNotUnmarshaTaskSignature(msg []byte, err error) ErrCouldNotUnmarshaTaskSignature {
 	return ErrCouldNotUnmarshaTaskSignature{msg: msg, reason: err.Error()}
 }
+
+// ErrConsumerStopped indicates that the operation is now illegal because of the consumer being stopped.
+var ErrConsumerStopped = errors.New("the server has been stopped")


### PR DESCRIPTION
This happens to me when I have an e2e test fixture setup as follows:
- `miniredis.Run()`  // setup
- `worker.Launch()`
- short test -- takes almost no time
- `worker.Quit()` // teardown
- `miniredis.Close()`

As `worker.Launch()` (or `LaunchAsync()`) starts redis.StartConsumer() in a goroutine, it is possible for `worker.Launch()` to return immediately and teardown code to be executed.

If `worker.Quit()` has been called, then it is unlikely for the Redis ping result to matter. So modified the code to return an appropriate error for client side checking.