### PR TITLE
Fix #465 - Sync DelayedTasksPollPeriod in config.go/redis.go

### DIFF
--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -41,7 +41,7 @@ var (
 			WriteTimeout:           15,
 			ConnectTimeout:         15,
 			NormalTasksPollPeriod:  1000,
-			DelayedTasksPollPeriod: 20,
+			DelayedTasksPollPeriod: 500,
 		},
 		GCPPubSub: &GCPPubSubConfig{
 			Client: nil,


### PR DESCRIPTION
Change default DelayedTasksPollPeriod from 20 ms to 500 ms