### PR TITLE
Expose delayed tasks via the broker

### DIFF
--- a/v1/brokers/eager/eager.go
+++ b/v1/brokers/eager/eager.go
@@ -62,11 +62,6 @@ func (eagerBroker *Broker) Publish(ctx context.Context, task *tasks.Signature) e
 	return eagerBroker.worker.Process(signature)
 }
 
-// GetPendingTasks returns a slice of task.Signatures waiting in the queue
-func (eagerBroker *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
-	return []*tasks.Signature{}, errors.New("Not implemented")
-}
-
 // AssignWorker assigns a worker to the eager broker
 func (eagerBroker *Broker) AssignWorker(w iface.TaskProcessor) {
 	eagerBroker.worker = w

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -16,6 +16,7 @@ type Broker interface {
 	StopConsuming()
 	Publish(ctx context.Context, task *tasks.Signature) error
 	GetPendingTasks(queue string) ([]*tasks.Signature, error)
+	GetDelayedTasks() ([]*tasks.Signature, error)
 	AdjustRoutingKey(s *tasks.Signature)
 }
 

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -57,11 +57,6 @@ func New(cnf *config.Config) iface.Broker {
 	return b
 }
 
-// GetPendingTasks returns a slice of task.Signatures waiting in the queue
-func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
-	return nil, errors.New("Not implemented")
-}
-
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)

--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -80,6 +80,11 @@ func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	return nil, errors.New("Not implemented")
 }
 
+// GetDelayedTasks returns a slice of task.Signatures that are scheduled, but not yet in the queue
+func (b *Broker) GetDelayedTasks() ([]*tasks.Signature, error) {
+	return nil, errors.New("Not implemented")
+}
+
 // StartConsuming is a common part of StartConsuming method
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) {
 	if b.retryFunc == nil {


### PR DESCRIPTION
Some broker implementations (like redis) use a separate queue for
delayed tasks. This commit exposes the contents of that queue via the
Broker interface so callers can see which tasks are scheduled with a
delay.