### PR TITLE
Change log level within amqp broker

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -330,7 +330,7 @@ func (b *Broker) consumeOne(delivery amqp.Delivery, taskProcessor iface.TaskProc
 		return nil
 	}
 
-	log.INFO.Printf("Received new message: %s", delivery.Body)
+	log.DEBUG.Printf("Received new message: %s", delivery.Body)
 
 	err := taskProcessor.Process(signature)
 	delivery.Ack(multiple)


### PR DESCRIPTION
The AMQP broker currently logs all message bodies at `INFO` level, which can cause a prohibitive amount of noise for those users who would like to enable other `INFO` logs.

This sort of logging is best handled at a `DEBUG` level (as it is in the Redis broker). 

This PR changes the relevant log level to `DEBUG`.