### PR TITLE
Feat: Support redis cluster with password

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ For example:
 1. `redis://localhost:6379`, or with password `redis://password@localhost:6379`
 2. `redis+socket://password@/path/to/file.sock:/0`
 3. cluster `redis://host1:port1,host2:port2,host3:port3`
+4. cluster with password `redis://pass@host1:port1,host2:port2,host3:port3`
 
 ##### Memcache
 

--- a/v1/backends/redis/goredis.go
+++ b/v1/backends/redis/goredis.go
@@ -3,9 +3,11 @@ package redis
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/go-redis/redis"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/go-redis/redis"
 
 	"github.com/RichardKnop/machinery/v1/backends/iface"
 	"github.com/RichardKnop/machinery/v1/common"
@@ -33,10 +35,19 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 	b := &BackendGR{
 		Backend: common.NewBackend(cnf),
 	}
-	ropt := &redis.UniversalOptions{
-		Addrs: addrs,
-		DB:    db,
+	parts := strings.Split(addrs[0], "@")
+	if len(parts) == 2 {
+		// with passwrod
+		b.password = parts[0]
+		addrs[0] = parts[1]
 	}
+
+	ropt := &redis.UniversalOptions{
+		Addrs:    addrs,
+		DB:       db,
+		Password: b.password,
+	}
+
 	b.rclient = redis.NewUniversalClient(ropt)
 	return b
 }

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -36,9 +36,19 @@ type BrokerGR struct {
 // New creates new Broker instance
 func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 	b := &BrokerGR{Broker: common.NewBroker(cnf)}
+
+	var password string
+	parts := strings.Split(addrs[0], "@")
+	if len(parts) == 2 {
+		// with passwrod
+		password = parts[0]
+		addrs[0] = parts[1]
+	}
+
 	ropt := &redis.UniversalOptions{
-		Addrs: addrs,
-		DB:    db,
+		Addrs:    addrs,
+		DB:       db,
+		Password: password,
 	}
 	b.rclient = redis.NewUniversalClient(ropt)
 	if cnf.Redis.DelayedTasksKey != "" {


### PR DESCRIPTION
Try to support Redis cluster with a password,  for both broker and backend.
```
broker: 'redis://pass@host1:port1,host2:port2,host3:port3'
result_backend: 'redis://pass@host1:port1,host2:port2,host3:port3'
```

How to test
REDIS_URL_GR=pass@localhost:7000,localhost:7001 go test