### PR TITLE
Delete SQS message if unmarshalling fails

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -209,6 +209,10 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
+		// if the unmarshal fails, remove the delivery from the queue
+		if err = b.deleteOne(delivery); err != nil {
+			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, err)
+		}
 		return err
 	}
 	if delivery.Messages[0].ReceiptHandle != nil {

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -210,8 +210,8 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
 		// if the unmarshal fails, remove the delivery from the queue
-		if err = b.deleteOne(delivery); err != nil {
-			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, err)
+		if delErr := b.deleteOne(delivery); delErr != nil {
+			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
 		}
 		return err
 	}


### PR DESCRIPTION
Delete message from SQS if message body is not valid JSON, could happen when producer is not based on machinery. If we don't delete the message, message will stay in "inflight", will keep getting retried after visibility timeout and will ultimately end up in DLQ