### PR TITLE
[DynamoDB] Support ResultsExpiresIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ dynamodb:
 ```
 If these tables are not found, an fatal error would be thrown.
 
+If you wish to expire the records, you can configure the `TTL` field in AWS admin for these tables. The `TTL` field is set based on the `ResultsExpireIn` value in the Server's config. See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/howitworks-ttl.html for more information.
+
 ### Custom Logger
 
 You can define a custom logger by implementing the following interface:

--- a/v1/backends/dynamodb/dynamodb.go
+++ b/v1/backends/dynamodb/dynamodb.go
@@ -52,6 +52,7 @@ func (b *Backend) InitGroup(groupUUID string, taskUUIDs []string) error {
 		GroupUUID: groupUUID,
 		TaskUUIDs: taskUUIDs,
 		CreatedAt: time.Now().UTC(),
+		TTL:       b.getExpirationTime(),
 	}
 	av, err := dynamodbattribute.MarshalMap(meta)
 	if err != nil {
@@ -164,12 +165,14 @@ func (b *Backend) SetStateRetry(signature *tasks.Signature) error {
 // SetStateSuccess ...
 func (b *Backend) SetStateSuccess(signature *tasks.Signature, results []*tasks.TaskResult) error {
 	taskState := tasks.NewSuccessTaskState(signature, results)
+	taskState.TTL = b.getExpirationTime()
 	return b.setTaskState(taskState)
 }
 
 // SetStateFailure ...
 func (b *Backend) SetStateFailure(signature *tasks.Signature, err string) error {
 	taskState := tasks.NewFailureTaskState(signature, err)
+	taskState.TTL = b.getExpirationTime()
 	return b.updateToFailureStateWithError(taskState)
 }
 
@@ -366,6 +369,13 @@ func (b *Backend) setTaskState(taskState *tasks.TaskState) error {
 		}
 		exp += ", #C = :c"
 	}
+	if taskState.TTL > 0 {
+		expAttributeNames["#T"] = aws.String("TTL")
+		expAttributeValues[":t"] = &dynamodb.AttributeValue{
+			N: aws.String(fmt.Sprintf("%d", taskState.TTL)),
+		}
+		exp += ", #T = :t"
+	}
 	if taskState.Results != nil && len(taskState.Results) != 0 {
 		expAttributeNames["#R"] = aws.String("Results")
 		var results []*dynamodb.AttributeValue
@@ -446,6 +456,14 @@ func (b *Backend) updateToFailureStateWithError(taskState *tasks.TaskState) erro
 		UpdateExpression: aws.String("SET #S = :s, #E = :e"),
 	}
 
+	if taskState.TTL > 0 {
+		input.ExpressionAttributeNames["#T"] = aws.String("TTL")
+		input.ExpressionAttributeValues[":t"] = &dynamodb.AttributeValue{
+			N: aws.String(fmt.Sprintf("%d", taskState.TTL)),
+		}
+		input.UpdateExpression = aws.String(aws.StringValue(input.UpdateExpression) + ", #T = :t")
+	}
+
 	_, err := b.client.UpdateItem(input)
 
 	if err != nil {
@@ -509,4 +527,13 @@ func (b *Backend) tableExists(tableName string, tableNames []*string) bool {
 		}
 	}
 	return false
+}
+
+func (b *Backend) getExpirationTime() int64 {
+	expiresIn := b.GetConfig().ResultsExpireIn
+	if expiresIn == 0 {
+		// expire results after 1 hour by default
+		expiresIn = config.DefaultResultsExpireIn
+	}
+	return time.Now().Add(time.Second * time.Duration(expiresIn)).Unix()
 }

--- a/v1/backends/dynamodb/dynamodb_export_test.go
+++ b/v1/backends/dynamodb/dynamodb_export_test.go
@@ -25,9 +25,19 @@ var (
 
 type TestDynamoDBClient struct {
 	dynamodbiface.DynamoDBAPI
+	PutItemOverride    func(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
+	UpdateItemOverride func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error)
 }
 
-func (t *TestDynamoDBClient) PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+func (t *TestDynamoDBClient) ResetOverrides() {
+	t.PutItemOverride = nil
+	t.UpdateItemOverride = nil
+}
+
+func (t *TestDynamoDBClient) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	if t.PutItemOverride != nil {
+		return t.PutItemOverride(input)
+	}
 	return &dynamodb.PutItemOutput{}, nil
 }
 
@@ -104,7 +114,10 @@ func (t *TestDynamoDBClient) DeleteItem(*dynamodb.DeleteItemInput) (*dynamodb.De
 	return &dynamodb.DeleteItemOutput{}, nil
 }
 
-func (t *TestDynamoDBClient) UpdateItem(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+func (t *TestDynamoDBClient) UpdateItem(input *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+	if t.UpdateItemOverride != nil {
+		return t.UpdateItemOverride(input)
+	}
 	return &dynamodb.UpdateItemOutput{}, nil
 }
 

--- a/v1/tasks/state.go
+++ b/v1/tasks/state.go
@@ -25,6 +25,7 @@ type TaskState struct {
 	Results   []*TaskResult `bson:"results"`
 	Error     string        `bson:"error"`
 	CreatedAt time.Time     `bson:"created_at"`
+	TTL       int64         `bson:"ttl,omitempty"`
 }
 
 // GroupMeta stores useful metadata about tasks within the same group
@@ -36,6 +37,7 @@ type GroupMeta struct {
 	ChordTriggered bool      `bson:"chord_triggered"`
 	Lock           bool      `bson:"lock"`
 	CreatedAt      time.Time `bson:"created_at"`
+	TTL            int64     `bson:"ttl,omitempty"`
 }
 
 // NewPendingTaskState ...


### PR DESCRIPTION
This PR implements setting the TTL value for DynamoDB records based on the `ResultsExpireIn` config value. (Issue https://github.com/RichardKnop/machinery/issues/518)
  - The TTL value is set only on terminal task states (SUCCESS & FAILURE).
  Because of retries, sometimes task completion (success or failure) may take longer than the configured expiration time. So we should not set TTL on non-terminal states (PENDING, RECEIVED, STARTED, RETRY)

  - Added tests.
  Provided method overrides to change the behavior of DynamoDB client. Tests assert that the correct state and TTL values are set for the given task.