### PR TITLE
[DynamoDB] Use uses strongly consistent reads

### DIFF
--- a/v1/backends/dynamodb/dynamodb.go
+++ b/v1/backends/dynamodb/dynamodb.go
@@ -182,6 +182,7 @@ func (b *Backend) GetState(taskUUID string) (*tasks.TaskState, error) {
 				S: aws.String(taskUUID),
 			},
 		},
+		ConsistentRead: aws.Bool(true),
 	})
 	if err != nil {
 		return nil, err
@@ -233,6 +234,7 @@ func (b *Backend) getGroupMeta(groupUUID string) (*tasks.GroupMeta, error) {
 				S: aws.String(groupUUID),
 			},
 		},
+		ConsistentRead: aws.Bool(true),
 	})
 	if err != nil {
 		log.ERROR.Printf("Error when getting group meta. Error: %v", err)


### PR DESCRIPTION
This PR address Issue https://github.com/RichardKnop/machinery/issues/525
Since the data fetched the result backend (DynamoDB in this case) is used to lock objects and to determine the completion of Groups, we need strongly consistent reads. Reading stale data causes bugs like the one mentioned in the above issue.

DynamoDB does not use strongly consistent reads by default unless explicitly asked for. This PR makes read requests explicitly ask for consistent data.