### PR TITLE
fix: wrong groupUUID in task span

### DIFF
--- a/v1/tracing/tracing.go
+++ b/v1/tracing/tracing.go
@@ -88,7 +88,7 @@ func AnnotateSpanWithSignatureInfo(span opentracing.Span, signature *tasks.Signa
 	span.SetTag("signature.uuid", signature.UUID)
 
 	if signature.GroupUUID != "" {
-		span.SetTag("signature.group.uuid", signature.UUID)
+		span.SetTag("signature.group.uuid", signature.GroupUUID)
 	}
 
 	if signature.ChordCallback != nil {


### PR DESCRIPTION
 Fix the issue that put taskUUID in groupUUID tag in task span.

![image](https://user-images.githubusercontent.com/738120/80567630-2e664280-8a28-11ea-97ea-729a612cefa4.png)
