### PR TITLE
Add support for preConsumeHandler in worker

### DIFF
--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -94,5 +95,37 @@ func TestRedisRedisWorkerQuickQuit(t *testing.T) {
 
 	if delta.Nanoseconds() > threshold.Nanoseconds() {
 		t.Error("Worker quit() exceeded timeout")
+	}
+}
+
+func TestRedisRedisWorkerPreConsumeHandler(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skip("REDIS_URL is not defined")
+	}
+
+	// Redis broker, Redis result backend
+	pollPeriod := 1
+	cnf := &config.Config{
+		Broker:        fmt.Sprintf("redis://%v", redisURL),
+		DefaultQueue:  "test_queue",
+		ResultBackend: fmt.Sprintf("redis://%v", redisURL),
+		Redis: &config.RedisConfig{
+			NormalTasksPollPeriod: pollPeriod, // default: 1000
+		},
+	}
+
+	server, _ := machinery.NewServer(cnf)
+	worker := server.NewWorker("test_worker", 0)
+	errorsChan := make(chan error)
+	err := errors.New("PreConsumeHandler is invoked")
+	worker.SetPreConsumeHandler(func(*machinery.Worker) bool {
+		errorsChan<-err
+		return true
+	})
+
+	worker.LaunchAsync(errorsChan)
+	if err != <-errorsChan {
+		t.Error("PreConsumeHandler was not invoked")
 	}
 }

--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -449,6 +449,10 @@ func (s *sigDumper) CustomQueue() string {
 	return s.customQueue
 }
 
+func (_ *sigDumper) PreConsumeHandler() bool {
+	return true
+}
+
 func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	if queue == "" {
 		queue = b.GetConfig().DefaultQueue

--- a/v1/brokers/amqp/amqp_concurrence_test.go
+++ b/v1/brokers/amqp/amqp_concurrence_test.go
@@ -19,6 +19,10 @@ func (_ doNothingProcessor) CustomQueue() string {
 	return "oops"
 }
 
+func (_ doNothingProcessor) PreConsumeHandler() bool {
+	return true
+}
+
 func TestConsume(t *testing.T) {
 	var (
 		iBroker iface.Broker

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -25,4 +25,5 @@ type Broker interface {
 type TaskProcessor interface {
 	Process(signature *tasks.Signature) error
 	CustomQueue() string
+	PreConsumeHandler() bool
 }

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/brokers/errs"
-	"github.com/RichardKnop/machinery/v1/brokers/iface"
+	"github.com/shivanshgaur/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/common"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/log"
@@ -100,10 +100,12 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 				close(deliveries)
 				return
 			case <-pool:
-				task, _ := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
-				//TODO: should this error be ignored?
-				if len(task) > 0 {
-					deliveries <- task
+				if taskProcessor.PreConsumeHandler() {
+					task, _ := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
+					//TODO: should this error be ignored?
+					if len(task) > 0 {
+						deliveries <- task
+					}
 				}
 
 				pool <- struct{}{}

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/brokers/errs"
-	"github.com/shivanshgaur/machinery/v1/brokers/iface"
+	"github.com/RichardKnop/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/common"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/log"

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -413,6 +413,10 @@ func (worker *Worker) GetServer() *Server {
 
 //
 func (worker *Worker) PreConsumeHandler() bool {
+	if worker.preConsumeHandler == nil {
+		return true
+	}
+
 	return worker.preConsumeHandler(worker)
 }
 

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -27,6 +27,7 @@ type Worker struct {
 	errorHandler    func(err error)
 	preTaskHandler  func(*tasks.Signature)
 	postTaskHandler func(*tasks.Signature)
+	preConsumeHandler func(*Worker) bool
 }
 
 var (
@@ -400,11 +401,20 @@ func (worker *Worker) SetPostTaskHandler(handler func(*tasks.Signature)) {
 	worker.postTaskHandler = handler
 }
 
+//SetPreConsumeHandler sets a custom handler for the end of a job
+func (worker *Worker) SetPreConsumeHandler(handler func(*Worker) bool) {
+	worker.preConsumeHandler = handler
+}
+
 //GetServer returns server
 func (worker *Worker) GetServer() *Server {
 	return worker.server
 }
 
+//
+func (worker *Worker) PreConsumeHandler() bool {
+	return worker.preConsumeHandler(worker)
+}
 
 func RedactURL(urlString string) string {
 	u, err := url.Parse(urlString)

--- a/v2/worker.go
+++ b/v2/worker.go
@@ -407,5 +407,9 @@ func (worker *Worker) GetServer() *Server {
 
 // PreConsumeHandler calls the handler before the task is popped
 func (worker *Worker) PreConsumeHandler() bool {
+	if worker.preConsumeHandler == nil {
+		return true
+	}
+
 	return worker.preConsumeHandler(worker)
 }

--- a/v2/worker.go
+++ b/v2/worker.go
@@ -28,6 +28,7 @@ type Worker struct {
 	errorHandler    func(err error)
 	preTaskHandler  func(*tasks.Signature)
 	postTaskHandler func(*tasks.Signature)
+	preConsumeHandler func(*Worker) bool
 }
 
 // Launch starts a new worker process. The worker subscribes
@@ -394,7 +395,17 @@ func (worker *Worker) SetPostTaskHandler(handler func(*tasks.Signature)) {
 	worker.postTaskHandler = handler
 }
 
+//SetPreConsumeHandler sets a custom handler func before the task is popped
+func (worker *Worker) SetPreConsumeHandler(handler func(*Worker) bool) {
+	worker.preConsumeHandler = handler
+}
+
 //GetServer returns server
 func (worker *Worker) GetServer() *Server {
 	return worker.server
+}
+
+// PreConsumeHandler calls the handler before the task is popped
+func (worker *Worker) PreConsumeHandler() bool {
+	return worker.preConsumeHandler(worker)
 }

--- a/v2/worker_test.go
+++ b/v2/worker_test.go
@@ -1,18 +1,10 @@
 package machinery_test
 
 import (
-	"github.com/RichardKnop/machinery/v1"
+	"github.com/RichardKnop/machinery/v2"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
-
-func TestRedactURL(t *testing.T) {
-	t.Parallel()
-
-	broker := "amqp://guest:guest@localhost:5672"
-	redactedURL := machinery.RedactURL(broker)
-	assert.Equal(t, "amqp://localhost:5672", redactedURL)
-}
 
 func TestPreConsumeHandler(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Adding support for `preConsumeHandler` to perform checks and then allow to pop messages from queues. This is in reference to issue #532 

Usage:
```go
server, _ := machinery.NewServer(config)
worker := server.NewWorker("test_worker", 0)
worker.SetPreConsumeHandler(func(w *machinery.Worker) bool {
    // perform checks; like rate limits
    // if allowed return true, else false
    return true
})

worker.Launch()
```