### PR TITLE
[Redis Broker] Wait for currently processing tasks to finish before closing the redis pool

### DIFF
--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -161,6 +161,8 @@ func (b *Broker) StopConsuming() {
 	b.delayedWG.Wait()
 	// Waiting for consumption to finish
 	b.consumingWG.Wait()
+	// Wait for currently processing tasks to finish as well.
+	b.processingWG.Wait()
 
 	if b.pool != nil {
 		b.pool.Close()


### PR DESCRIPTION
The redis broker sometimes shuts down before currently processing tasks are complete. This typically is not an issue except when these running tasks wish to publish other tasks before completing. Since the `StopConsuming()` method closes the Redis pool, publishing of new tasks fail as well.

This PR waits for the tasks currently being processed before closing the redis pool.