### PR TITLE
Fix #529 - Set Redis default concurrency when value is 0

### DIFF
--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -67,7 +68,7 @@ func (b *BrokerGR) StartConsuming(consumerTag string, concurrency int, taskProce
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = 1
+		concurrency = runtime.NumCPU() * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -54,7 +55,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = 1
+		concurrency = runtime.NumCPU() * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)


### PR DESCRIPTION
According to the README:
> Use the second parameter of `server.NewWorker` to limit the number of concurrently running
> worker.Process() calls (per worker). Example: 1 will serialize task execution while 0 makes
> the number of concurrently executed tasks unlimited (default).

This change will set the concurrency to 2 * num CPUs when concurrency = 0. While it isn't "unlimited", it is neverthe a practical choice for most workloads (mixed CPU, I/O) and better than 1. This change should make the behavior more consistent with the doc.

Should also fix #535