### PR TITLE
Fix typo in config.go

### DIFF
--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	SQS                     *SQSConfig       `yaml:"sqs"`
 	Redis                   *RedisConfig     `yaml:"redis"`
 	GCPPubSub               *GCPPubSubConfig `yaml:"-" ignored:"true"`
-	MongoDB                 *MongoDBConfig   `yamk:"-" ignored:"true"`
+	MongoDB                 *MongoDBConfig   `yaml:"-" ignored:"true"`
 	TLSConfig               *tls.Config
 	// NoUnixSignals - when set disables signal handling in machinery
 	NoUnixSignals bool            `yaml:"no_unix_signals" envconfig:"NO_UNIX_SIGNALS"`

--- a/v1/config/file_test.go
+++ b/v1/config/file_test.go
@@ -1,8 +1,6 @@
 package config_test
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/RichardKnop/machinery/v1/config"
@@ -24,6 +22,25 @@ amqp:
   queue_binding_args:
     image-type: png
     x-match: any
+sqs:
+  receive_wait_time_seconds: 123
+  receive_visibility_timeout: 456
+redis:
+  max_idle: 12
+  max_active: 123
+  max_idle_timeout: 456
+  wait: false
+  read_timeout: 17
+  write_timeout: 19
+  connect_timeout: 21
+  normal_tasks_poll_period: 1001
+  delayed_tasks_poll_period: 23
+  delayed_tasks_key: delayed_tasks_key
+  master_name: master_name
+no_unix_signals: true
+dynamodb:
+  task_states_table: task_states_table
+  group_metas_table: group_metas_table
 `
 
 func TestReadFromFile(t *testing.T) {
@@ -32,16 +49,7 @@ func TestReadFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(data) == configYAMLData && err == nil {
-		return
-	}
-
-	var buffer bytes.Buffer
-	buffer.WriteString(
-		fmt.Sprintf("Expected value:\n%v\n", configYAMLData))
-	buffer.WriteString(
-		fmt.Sprintf("Actual value:\n%v\n", string(data)))
-	t.Error(buffer.String())
+	assert.Equal(t, configYAMLData, string(data))
 }
 
 func TestNewFromYaml(t *testing.T) {
@@ -54,6 +62,7 @@ func TestNewFromYaml(t *testing.T) {
 	assert.Equal(t, "default_queue", cnf.DefaultQueue)
 	assert.Equal(t, "result_backend", cnf.ResultBackend)
 	assert.Equal(t, 123456, cnf.ResultsExpireIn)
+
 	assert.Equal(t, "exchange", cnf.AMQP.Exchange)
 	assert.Equal(t, "exchange_type", cnf.AMQP.ExchangeType)
 	assert.Equal(t, "binding_key", cnf.AMQP.BindingKey)
@@ -61,4 +70,24 @@ func TestNewFromYaml(t *testing.T) {
 	assert.Equal(t, "any", cnf.AMQP.QueueBindingArgs["x-match"])
 	assert.Equal(t, "png", cnf.AMQP.QueueBindingArgs["image-type"])
 	assert.Equal(t, 123, cnf.AMQP.PrefetchCount)
+
+	assert.Equal(t, 123, cnf.SQS.WaitTimeSeconds)
+	assert.Equal(t, 456, *cnf.SQS.VisibilityTimeout)
+
+	assert.Equal(t, 12, cnf.Redis.MaxIdle)
+	assert.Equal(t, 123, cnf.Redis.MaxActive)
+	assert.Equal(t, 456, cnf.Redis.IdleTimeout)
+	assert.Equal(t, false, cnf.Redis.Wait)
+	assert.Equal(t, 17, cnf.Redis.ReadTimeout)
+	assert.Equal(t, 19, cnf.Redis.WriteTimeout)
+	assert.Equal(t, 21, cnf.Redis.ConnectTimeout)
+	assert.Equal(t, 1001, cnf.Redis.NormalTasksPollPeriod)
+	assert.Equal(t, 23, cnf.Redis.DelayedTasksPollPeriod)
+	assert.Equal(t, "delayed_tasks_key", cnf.Redis.DelayedTasksKey)
+	assert.Equal(t, "master_name", cnf.Redis.MasterName)
+
+	assert.Equal(t, true, cnf.NoUnixSignals)
+
+	assert.Equal(t, "task_states_table", cnf.DynamoDB.TaskStatesTable)
+	assert.Equal(t, "group_metas_table", cnf.DynamoDB.GroupMetasTable)
 }

--- a/v1/config/testconfig.yml
+++ b/v1/config/testconfig.yml
@@ -13,3 +13,22 @@ amqp:
   queue_binding_args:
     image-type: png
     x-match: any
+sqs:
+  receive_wait_time_seconds: 123
+  receive_visibility_timeout: 456
+redis:
+  max_idle: 12
+  max_active: 123
+  max_idle_timeout: 456
+  wait: false
+  read_timeout: 17
+  write_timeout: 19
+  connect_timeout: 21
+  normal_tasks_poll_period: 1001
+  delayed_tasks_poll_period: 23
+  delayed_tasks_key: delayed_tasks_key
+  master_name: master_name
+no_unix_signals: true
+dynamodb:
+  task_states_table: task_states_table
+  group_metas_table: group_metas_table


### PR DESCRIPTION
Re-apply 342ef9fe; also update test to include other yaml options.