### PR TITLE
Use UNWATCH when MULTI is not called

### DIFF
--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -378,7 +378,9 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 	defer func() {
 		// Return connection to normal state on error.
 		// https://redis.io/commands/discard
-		if err != nil {
+		if err == redis.ErrNil {
+			conn.Do("UNWATCH")
+		} else if err != nil {
 			conn.Do("DISCARD")
 		}
 	}()

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -378,6 +378,7 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 	defer func() {
 		// Return connection to normal state on error.
 		// https://redis.io/commands/discard
+		// https://redis.io/commands/unwatch
 		if err == redis.ErrNil {
 			conn.Do("UNWATCH")
 		} else if err != nil {


### PR DESCRIPTION
When `DISCARD` is called without calling `MULTI` it gives following error:
`(error) ERR DISCARD without MULTI`

Such use of `DISCARD` also seems to be causing issues with blocking commands on certain Redis machines where blocking pop(i.e. `BLPOP`) does not timeout.