### PR TITLE
chain async GetWithTimeout should use correct err

### DIFF
--- a/v1/backends/result/async_result.go
+++ b/v1/backends/result/async_result.go
@@ -201,8 +201,8 @@ func (chainAsyncResult *ChainAsyncResult) GetWithTimeout(timeoutDuration, sleepD
 		default:
 
 			for _, asyncResult := range chainAsyncResult.asyncResults {
-				_, errcur := asyncResult.Touch()
-				if errcur != nil {
+				_, err = asyncResult.Touch()
+				if err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
Found a bug in `GetWithTimeout` for `chainAsyncResult` where it was using the wrong `err` object named `errcurr` but didn't return that error. Fixing it for you since it bugged me