### PR TITLE
ensure consuming blocked by previous task (#559)

### DIFF
--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -82,10 +82,12 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	// Channel to which we will push tasks ready for processing by worker
 	deliveries := make(chan []byte, concurrency)
 	pool := make(chan struct{}, concurrency)
+	nextTask := make(chan struct{}, concurrency)
 
 	// initialize worker pool with maxWorkers workers
 	for i := 0; i < concurrency; i++ {
 		pool <- struct{}{}
+		nextTask <- struct{}{}
 	}
 
 	// A receiving goroutine keeps popping messages from the queue by BLPOP
@@ -110,6 +112,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 				}
 
 				if taskProcessor.PreConsumeHandler() {
+					<-nextTask
 					task, _ := b.nextTask(getQueue(b.GetConfig(), taskProcessor))
 					//TODO: should this error be ignored?
 					if len(task) > 0 {
@@ -153,7 +156,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 		}
 	}()
 
-	if err := b.consume(deliveries, concurrency, taskProcessor); err != nil {
+	if err := b.consume(deliveries, nextTask, concurrency, taskProcessor); err != nil {
 		return b.GetRetry(), err
 	}
 
@@ -266,7 +269,7 @@ func (b *Broker) GetDelayedTasks() ([]*tasks.Signature, error) {
 
 // consume takes delivered messages from the channel and manages a worker pool
 // to process tasks concurrently
-func (b *Broker) consume(deliveries <-chan []byte, concurrency int, taskProcessor iface.TaskProcessor) error {
+func (b *Broker) consume(deliveries <-chan []byte, nextTask chan<- struct{}, concurrency int, taskProcessor iface.TaskProcessor) error {
 	errorsChan := make(chan error, concurrency*2)
 	pool := make(chan struct{}, concurrency)
 
@@ -300,6 +303,10 @@ func (b *Broker) consume(deliveries <-chan []byte, concurrency int, taskProcesso
 			// Consume the task inside a goroutine so multiple tasks
 			// can be processed concurrently
 			go func() {
+				defer func() {
+					nextTask <- struct{}{}
+				}()
+
 				if err := b.consumeOne(d, taskProcessor); err != nil {
 					errorsChan <- err
 				}


### PR DESCRIPTION
more than concurrency count tasks would be gotten in former code, thus add a channel for receiving previous task end signal, which would block taking task from redis, solving the problem mentioned in #559
