### PR TITLE
Failed task signature on error handler

### DIFF
--- a/example/machinery.go
+++ b/example/machinery.go
@@ -127,8 +127,8 @@ func worker() error {
 
 	// Here we inject some custom code for error handling,
 	// start and end of task hooks, useful for metrics for example.
-	errorhandler := func(err error) {
-		log.ERROR.Println("I am an error handler:", err)
+	errorhandler := func(signature *tasks.Signature, err error) {
+		log.ERROR.Println("I am an error handler:", signature.UUID, err)
 	}
 
 	pretaskhandler := func(signature *tasks.Signature) {


### PR DESCRIPTION
Current error handler only accept error as arguments, I propose to add failed task signature to make it more useful.
Some use case is when we need to broadcast error event about failed task to notify other system.