### PR TITLE
Fix issues #127 and #126

### DIFF
--- a/example/v1/amqp/main.go
+++ b/example/v1/amqp/main.go
@@ -30,15 +30,13 @@ func init() {
 	app = cli.NewApp()
 	app.Name = "machinery"
 	app.Usage = "machinery worker and send example tasks with machinery send"
-	app.Author = "Richard Knop"
-	app.Email = "risoknop@gmail.com"
 	app.Version = "0.0.0"
 }
 
 func main() {
 	// Set the CLI app commands
-	app.Commands = []cli.Command{
-		{
+	app.Commands = []*cli.Command{
+		&cli.Command{
 			Name:  "worker",
 			Usage: "launch machinery worker",
 			Action: func(c *cli.Context) error {
@@ -48,7 +46,7 @@ func main() {
 				return nil
 			},
 		},
-		{
+		&cli.Command{
 			Name:  "send",
 			Usage: "send example tasks ",
 			Action: func(c *cli.Context) error {

--- a/example/v1/redis/main.go
+++ b/example/v1/redis/main.go
@@ -30,15 +30,13 @@ func init() {
 	app = cli.NewApp()
 	app.Name = "machinery"
 	app.Usage = "machinery worker and send example tasks with machinery send"
-	app.Author = "Richard Knop"
-	app.Email = "risoknop@gmail.com"
 	app.Version = "0.0.0"
 }
 
 func main() {
 	// Set the CLI app commands
-	app.Commands = []cli.Command{
-		{
+	app.Commands = []*cli.Command{
+		&cli.Command{
 			Name:  "worker",
 			Usage: "launch machinery worker",
 			Action: func(c *cli.Context) error {
@@ -48,7 +46,7 @@ func main() {
 				return nil
 			},
 		},
-		{
+		&cli.Command{
 			Name:  "send",
 			Usage: "send example tasks ",
 			Action: func(c *cli.Context) error {

--- a/example/v2/amqp/main.go
+++ b/example/v2/amqp/main.go
@@ -33,15 +33,13 @@ func init() {
 	app = cli.NewApp()
 	app.Name = "machinery"
 	app.Usage = "machinery worker and send example tasks with machinery send"
-	app.Author = "Richard Knop"
-	app.Email = "risoknop@gmail.com"
 	app.Version = "0.0.0"
 }
 
 func main() {
 	// Set the CLI app commands
-	app.Commands = []cli.Command{
-		{
+	app.Commands = []*cli.Command{
+		&cli.Command{
 			Name:  "worker",
 			Usage: "launch machinery worker",
 			Action: func(c *cli.Context) error {
@@ -51,7 +49,7 @@ func main() {
 				return nil
 			},
 		},
-		{
+		&cli.Command{
 			Name:  "send",
 			Usage: "send example tasks ",
 			Action: func(c *cli.Context) error {

--- a/example/v2/go-redis/main.go
+++ b/example/v2/go-redis/main.go
@@ -33,15 +33,13 @@ func init() {
 	app = cli.NewApp()
 	app.Name = "machinery"
 	app.Usage = "machinery worker and send example tasks with machinery send"
-	app.Author = "Richard Knop"
-	app.Email = "risoknop@gmail.com"
 	app.Version = "0.0.0"
 }
 
 func main() {
 	// Set the CLI app commands
-	app.Commands = []cli.Command{
-		{
+	app.Commands = []*cli.Command{
+		&cli.Command{
 			Name:  "worker",
 			Usage: "launch machinery worker",
 			Action: func(c *cli.Context) error {
@@ -51,7 +49,7 @@ func main() {
 				return nil
 			},
 		},
-		{
+		&cli.Command{
 			Name:  "send",
 			Usage: "send example tasks ",
 			Action: func(c *cli.Context) error {

--- a/example/v2/redigo/main.go
+++ b/example/v2/redigo/main.go
@@ -33,15 +33,13 @@ func init() {
 	app = cli.NewApp()
 	app.Name = "machinery"
 	app.Usage = "machinery worker and send example tasks with machinery send"
-	app.Author = "Richard Knop"
-	app.Email = "risoknop@gmail.com"
 	app.Version = "0.0.0"
 }
 
 func main() {
 	// Set the CLI app commands
-	app.Commands = []cli.Command{
-		{
+	app.Commands = []*cli.Command{
+		&cli.Command{
 			Name:  "worker",
 			Usage: "launch machinery worker",
 			Action: func(c *cli.Context) error {
@@ -51,7 +49,7 @@ func main() {
 				return nil
 			},
 		},
-		{
+		&cli.Command{
 			Name:  "send",
 			Usage: "send example tasks ",
 			Action: func(c *cli.Context) error {

--- a/v1/locks/redis/redis.go
+++ b/v1/locks/redis/redis.go
@@ -66,13 +66,15 @@ func (r Lock) LockWithRetries(key string, value int64) error {
 func (r Lock) Lock(key string, value int64) error {
 	var now = time.Now().UnixNano()
 
-	success, err := r.rclient.SetNX(key, value, time.Duration(value+1)).Result()
+	ctx := r.rclient.Context()
+
+	success, err := r.rclient.SetNX(ctx, key, value, time.Duration(value+1)).Result()
 	if err != nil {
 		return err
 	}
 
 	if !success {
-		v, err := r.rclient.Get(key).Result()
+		v, err := r.rclient.Get(ctx, key).Result()
 		if err != nil {
 			return err
 		}
@@ -82,7 +84,7 @@ func (r Lock) Lock(key string, value int64) error {
 		}
 
 		if timeout != 0 && now > int64(timeout) {
-			newTimeout, err := r.rclient.GetSet(key, value).Result()
+			newTimeout, err := r.rclient.GetSet(ctx, key, value).Result()
 			if err != nil {
 				return err
 			}
@@ -95,7 +97,7 @@ func (r Lock) Lock(key string, value int64) error {
 			if now > int64(curTimeout) {
 				// success to acquire lock with get set
 				// set the expiration of redis key
-				r.rclient.Expire(key, time.Duration(value+1))
+				r.rclient.Expire(ctx, key, time.Duration(value+1))
 				return nil
 			}
 


### PR DESCRIPTION
To fix the issue with missing context arguments to redis calls in `/v1/lock/redis/redis.go`, I simply pulled the context out of the Redis client and passed in where needed.