### PR TITLE
Update Redis lock connection string parsing.

### DIFF
--- a/v1/locks/redis/redis.go
+++ b/v1/locks/redis/redis.go
@@ -28,11 +28,10 @@ func New(cnf *config.Config, addrs []string, db, retries int) Lock {
 
 	var password string
 
-	i := strings.LastIndex(addrs[0], "@")
-	if i > 0 {
-		// with passwrod
-		password = addrs[0][i+1:]
-		addrs[0] = addrs[0][:i]
+	parts := strings.Split(addrs[0], "@")
+	if len(parts) == 2 {
+		password = parts[0]
+		addrs[0] = parts[1]
 	}
 
 	ropt := &redis.UniversalOptions{


### PR DESCRIPTION
The previous code would fail to parse a password from a connection string if the password was empty. This uses the code used in, e.g., https://github.com/RichardKnop/machinery/blob/master/v1/brokers/redis/goredis.go#L43, as well as the backend.