### PR TITLE
add PublishToLocal for health check

### DIFF
--- a/integration-tests/amqp_amqp_test.go
+++ b/integration-tests/amqp_amqp_test.go
@@ -43,7 +43,9 @@ func TestAmqpAmqp(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/amqp_memcache_test.go
+++ b/integration-tests/amqp_memcache_test.go
@@ -39,7 +39,9 @@ func TestAmqpMemcache(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/amqp_mongodb_test.go
+++ b/integration-tests/amqp_mongodb_test.go
@@ -35,7 +35,9 @@ func TestAmqpMongodb(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/amqp_redis_test.go
+++ b/integration-tests/amqp_redis_test.go
@@ -34,7 +34,9 @@ func TestAmqpRedis(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/gcppubsub_redis_test.go
+++ b/integration-tests/gcppubsub_redis_test.go
@@ -95,7 +95,10 @@ func TestGCPPubSubRedis(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	// not supported
+	// testPubslishToLocal(server, t)
 }

--- a/integration-tests/redis_memcache_test.go
+++ b/integration-tests/redis_memcache_test.go
@@ -28,7 +28,9 @@ func TestRedisMemcache(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/redis_mongodb_test.go
+++ b/integration-tests/redis_mongodb_test.go
@@ -29,7 +29,9 @@ func TestRedisMongodb(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/redis_redis_test.go
+++ b/integration-tests/redis_redis_test.go
@@ -26,9 +26,11 @@ func TestRedisRedis_Redigo(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }
 
 func TestRedisRedisNormalTaskPollPeriodLessThan1SecondShouldNotFailNextTask(t *testing.T) {

--- a/integration-tests/redis_socket_test.go
+++ b/integration-tests/redis_socket_test.go
@@ -24,7 +24,9 @@ func TestRedisSocket(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/sqs_amqp_test.go
+++ b/integration-tests/sqs_amqp_test.go
@@ -34,7 +34,9 @@ func TestSQSAmqp(t *testing.T) {
 	})
 
 	worker := server.(*machinery.Server).NewWorker("test_worker", 0)
-	defer worker.Quit()
 	go worker.Launch()
 	testAll(server, t)
+	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/integration-tests/sqs_mongodb_test.go
+++ b/integration-tests/sqs_mongodb_test.go
@@ -31,4 +31,6 @@ func TestSQSMongodb(t *testing.T) {
 	go worker.Launch()
 	testAll(server, t)
 	worker.Quit()
+
+	testPubslishToLocal(server, t)
 }

--- a/v1/brokers/amqp/amqp_concurrence_test.go
+++ b/v1/brokers/amqp/amqp_concurrence_test.go
@@ -26,10 +26,11 @@ func (_ doNothingProcessor) PreConsumeHandler() bool {
 
 func TestConsume(t *testing.T) {
 	var (
-		iBroker    iface.Broker
-		deliveries = make(chan amqp.Delivery, 3)
-		closeChan  chan *amqp.Error
-		processor  doNothingProcessor
+		iBroker         iface.Broker
+		deliveries      = make(chan amqp.Delivery, 3)
+		localDeliveries = make(chan amqp.Delivery)
+		closeChan       chan *amqp.Error
+		processor       doNothingProcessor
 	)
 
 	t.Run("with deliveries more than the number of concurrency", func(t *testing.T) {
@@ -45,7 +46,7 @@ func TestConsume(t *testing.T) {
 		}()
 
 		go func() {
-			err := broker.consume(deliveries, 2, processor, closeChan)
+			err := broker.consume(deliveries, 2, processor, closeChan, localDeliveries)
 			if err != nil {
 				errChan <- err
 			}

--- a/v1/brokers/eager/eager.go
+++ b/v1/brokers/eager/eager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/common"
@@ -65,4 +66,8 @@ func (eagerBroker *Broker) Publish(ctx context.Context, task *tasks.Signature) e
 // AssignWorker assigns a worker to the eager broker
 func (eagerBroker *Broker) AssignWorker(w iface.TaskProcessor) {
 	eagerBroker.worker = w
+}
+
+func (b *Broker) PublishToLocal(consumerTag string, sig *tasks.Signature, blockTimeout time.Duration) error {
+	return b.Publish(context.Background(), sig)
 }

--- a/v1/brokers/gcppubsub/gcp_pubsub.go
+++ b/v1/brokers/gcppubsub/gcp_pubsub.go
@@ -194,3 +194,8 @@ func (b *Broker) consumeOne(delivery *pubsub.Message, taskProcessor iface.TaskPr
 	// Call Ack() after successfully consuming and processing the message
 	delivery.Ack()
 }
+
+// not supported
+func (b *Broker) PublishToLocal(consumerTag string, sig *tasks.Signature, blockTimeout time.Duration) error {
+	return fmt.Errorf("gcp pubsub not support PublishToLocal")
+}

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"context"
+	"time"
 
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
@@ -18,6 +19,8 @@ type Broker interface {
 	GetPendingTasks(queue string) ([]*tasks.Signature, error)
 	GetDelayedTasks() ([]*tasks.Signature, error)
 	AdjustRoutingKey(s *tasks.Signature)
+	// send messages to local workers
+	PublishToLocal(consumerTag string, sig *tasks.Signature, t time.Duration) error
 }
 
 // TaskProcessor - can process a delivered task

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -34,11 +34,13 @@ type BrokerGR struct {
 	redsync              *redsync.Redsync
 	redisOnce            sync.Once
 	redisDelayedTasksKey string
+	deliveriesMap        map[string]chan []byte
+	deliveriesMapMutex   sync.RWMutex
 }
 
 // NewGR creates new Broker instance
 func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
-	b := &BrokerGR{Broker: common.NewBroker(cnf)}
+	b := &BrokerGR{Broker: common.NewBroker(cnf), deliveriesMap: make(map[string]chan []byte)}
 
 	var password string
 	parts := strings.Split(addrs[0], "@")
@@ -95,6 +97,9 @@ func (b *BrokerGR) StartConsuming(consumerTag string, concurrency int, taskProce
 	// Channel to which we will push tasks ready for processing by worker
 	deliveries := make(chan []byte, concurrency)
 	pool := make(chan struct{}, concurrency)
+	b.deliveriesMapMutex.Lock()
+	b.deliveriesMap[consumerTag] = deliveries
+	b.deliveriesMapMutex.Unlock()
 
 	// initialize worker pool with maxWorkers workers
 	for i := 0; i < concurrency; i++ {
@@ -419,4 +424,23 @@ func getQueueGR(config *config.Config, taskProcessor iface.TaskProcessor) string
 		return config.DefaultQueue
 	}
 	return customQueue
+}
+
+func (b *BrokerGR) PublishToLocal(consumerTag string, sig *tasks.Signature, blockTimeout time.Duration) error {
+	b.deliveriesMapMutex.RLock()
+	deliveries, ok := b.deliveriesMap[consumerTag]
+	b.deliveriesMapMutex.RUnlock()
+	if !ok {
+		return fmt.Errorf("no such consumerTag: %v", consumerTag)
+	}
+	msg, err := json.Marshal(sig)
+	if err != nil {
+		return fmt.Errorf("JSON marshal error: %s", err)
+	}
+	select {
+	case deliveries <- msg:
+		return nil
+	case <-time.After(blockTimeout):
+		return fmt.Errorf("health check: %v queue is full.", consumerTag)
+	}
 }

--- a/v1/server_test.go
+++ b/v1/server_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	
+
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 )
@@ -37,7 +37,7 @@ func TestRegisterTaskInRaceCondition(t *testing.T) {
 	t.Parallel()
 
 	server := getTestServer(t)
-	for i:=0; i<10; i++ {
+	for i := 0; i < 10; i++ {
 		go func() {
 			err := server.RegisterTask("test_task", func() error { return nil })
 			assert.NoError(t, err)

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	
+
 	"github.com/RichardKnop/machinery/v1/backends/amqp"
 	"github.com/RichardKnop/machinery/v1/brokers/errs"
 	"github.com/RichardKnop/machinery/v1/log"

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -18,7 +18,7 @@ func TestRedactURL(t *testing.T) {
 
 func TestPreConsumeHandler(t *testing.T) {
 	t.Parallel()
-	
+
 	worker := &machinery.Worker{}
 
 	worker.SetPreConsumeHandler(SamplePreConsumeHandler)


### PR DESCRIPTION
I need a health check function to check if the local worker can still run properly (e.g. if all the goroutines are stuck and can't start new ones due to concurrency).

One way to do this is to check if the local worker can run and complete a new task in the expected time. So I need a `PublishToLocal` method.

---

A health check example:

```go
var healthCheckCompleteChan = make(chan string, 1)

...
	server.RegisterTask(healthCheckTaskName, func(healthCheckUUID string) error {
		select {
		case healthCheckCompleteChan <- healthCheckUUID: // success and send uuid
			return nil
		case <-time.After(5 * time.Second):
			return fmt.Errorf("send health check result error: %v", healthCheckUUID)
		}
	})
...

func checkHealth(consumerTag string, taskExecutionTimeout time.Duration) error {
	// clear channel
	select {
	case <-healthCheckCompleteChan:
	default:
	}

	broker := server.GetBroker()
	healthCheckUUID, err := uuid.NewUUID()
	if err != nil {
		return err
	}
	if err := broker.PublishToLocal(consumerTag, &tasks.Signature{
		UUID: healthCheckUUID.String(),
		Name: healthCheckTaskName,
		Args: []tasks.Arg{
			{Type: "string", Value: healthCheckUUID.String()},
		},
	}, 5*time.Second); err != nil {
		return err
	}

	// wait for task execution success
	select {
	case successUUID := <-healthCheckCompleteChan:
		if successUUID == healthCheckUUID.String() {
			return nil
		}
	case <-time.After(taskExecutionTimeout):
	}
	return fmt.Errorf("health check execution fail: %v", healthCheckUUID.String())
}
```

Then I can run `checkHealth(consumerTag, TasksShouldBeCompletedIn)` method and do the appropriate processing.