### PR TITLE
feat: add redis cluster mode flag in redis config

### DIFF
--- a/v1/backends/redis/goredis.go
+++ b/v1/backends/redis/goredis.go
@@ -53,7 +53,12 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 
-	b.rclient = redis.NewUniversalClient(ropt)
+	if cnf.Redis != nil && cnf.Redis.ClusterMode {
+		b.rclient = redis.NewClusterClient(ropt.Cluster())
+	} else {
+
+		b.rclient = redis.NewUniversalClient(ropt)
+	}
 	b.redsync = redsync.New(redsyncgoredis.NewPool(b.rclient))
 	return b
 }

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -57,7 +57,12 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 
-	b.rclient = redis.NewUniversalClient(ropt)
+	if cnf.Redis != nil && cnf.Redis.ClusterMode {
+		b.rclient = redis.NewClusterClient(ropt.Cluster())
+	} else {
+		b.rclient = redis.NewUniversalClient(ropt)
+	}
+
 	if cnf.Redis.DelayedTasksKey != "" {
 		b.redisDelayedTasksKey = cnf.Redis.DelayedTasksKey
 	} else {

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -149,6 +149,8 @@ type RedisConfig struct {
 
 	// MasterName specifies a redis master name in order to configure a sentinel-backed redis FailoverClient
 	MasterName string `yaml:"master_name" envconfig:"REDIS_MASTER_NAME"`
+	// ClusterMode specifies machinery should use redis cluster client explicitly
+	ClusterMode bool `yaml:"cluster_mode" envconfig:"REDIS_CLUSTER_MODE"`
 }
 
 // GCPPubSubConfig wraps GCP PubSub related configuration

--- a/v1/factories.go
+++ b/v1/factories.go
@@ -58,7 +58,7 @@ func BrokerFactory(cnf *config.Config) (brokeriface.Broker, error) {
 			)
 		}
 		brokers := strings.Split(parts[1], ",")
-		if len(brokers) > 1 {
+		if len(brokers) > 1 || (cnf.Redis != nil && cnf.Redis.ClusterMode) {
 			return redisbroker.NewGR(cnf, brokers, 0), nil
 		} else {
 			redisHost, redisPassword, redisDB, err := ParseRedisURL(cnf.Broker)
@@ -140,7 +140,7 @@ func BackendFactory(cnf *config.Config) (backendiface.Backend, error) {
 		}
 		parts := strings.Split(cnf.ResultBackend, scheme)
 		addrs := strings.Split(parts[1], ",")
-		if len(addrs) > 1 {
+		if len(addrs) > 1 || (cnf.Redis != nil && cnf.Redis.ClusterMode) {
 			return redisbackend.NewGR(cnf, addrs, 0), nil
 		} else {
 			redisHost, redisPassword, redisDB, err := ParseRedisURL(cnf.ResultBackend)


### PR DESCRIPTION
With the cluster mode flag, we can explicitly use Redis cluster client,
instead of universal client controlling by Redis universal client logic.
So it can support a single configuration endpoint for Redis

related issue: https://github.com/RichardKnop/machinery/issues/701