### PR TITLE
Added timeout callback to the worker

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -231,6 +231,9 @@ func (worker *Worker) retryTaskIn(signature *tasks.Signature, retryIn time.Durat
 		return fmt.Errorf("Set state to 'retry' for task %s returned error: %s", signature.UUID, err)
 	}
 
+	// Decrement the retry counter, when it reaches 0, we won't retry again
+	signature.RetryCount--
+
 	// Delay task by retryIn duration
 	eta := time.Now().UTC().Add(retryIn)
 	signature.ETA = &eta

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -238,6 +238,10 @@ func (worker *Worker) retryTaskIn(signature *tasks.Signature, retryIn time.Durat
 	eta := time.Now().UTC().Add(retryIn)
 	signature.ETA = &eta
 
+	if signature.RetryCount == 0 {
+		return worker.taskFailed(signature, errors.New("Task failed too many times."))
+	}
+
 	log.WARNING.Printf("Task %s failed. Going to retry in %.0f seconds.", signature.UUID, retryIn.Seconds())
 
 	// Send the task back to the queue


### PR DESCRIPTION
This will enable the user to configure to set a fixed time in seconds between each retry to send a task to their queue, instead of only being able to use Fibonacci.