### PR TITLE
fix: make sure eager lock is concurrent safe

### DIFF
--- a/v2/locks/eager/eager.go
+++ b/v2/locks/eager/eager.go
@@ -44,8 +44,8 @@ func (e *Lock) LockWithRetries(key string, value int64) error {
 }
 
 func (e *Lock) Lock(key string, value int64) error {
-	e.register.RLock()
-	defer e.register.RUnlock()
+	e.register.Lock()
+	defer e.register.Unlock()
 	timeout, exist := e.register.m[key]
 	if !exist || time.Now().UnixNano() > timeout {
 		e.register.m[key] = value


### PR DESCRIPTION
# V1 concurrent race

`(1)` read lock won't exclude other read locks. it's useless here.

Although `register.m` is `sync.Map`, but reading and writing are two operations. If two goroutines read empty `register.m` at the same time, exists will be false. Then the two goroutines will get lock at the same time.

```go
func (e *Lock) Lock(key string, value int64) error {
	e.register.RLock() // (1) read lock
	defer e.register.RUnlock()
	timeout, exist := e.register.m.Load(key) // (2) read
	if !exist || time.Now().UnixNano() > timeout.(int64) {
		e.register.m.Store(key, value) // (3) write
		return nil
	}
	return ErrEagerLockFailed
}
```

# V2 concurrent race

When run go test with race flag `go test -race ./locks/eager`, will got these warning.

```
==================
WARNING: DATA RACE
Read at 0x00c0001152f0 by goroutine 7:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/map_faststr.go:12 +0x45c
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:49 +0xb0
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:20 +0x1c8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198

Previous write at 0x00c0001152f0 by goroutine 8:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:107 +0x48c
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:51 +0x1a4
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock.func1()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:16 +0xdc

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:47 +0x288

Goroutine 8 (finished) created at:
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:15 +0x100
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
==================
==================
WARNING: DATA RACE
Read at 0x00c000117e98 by goroutine 7:
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:49 +0xc8
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:20 +0x1c8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198

Previous write at 0x00c000117e98 by goroutine 8:
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:51 +0x1b8
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock.func1()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:16 +0xdc

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:47 +0x288

Goroutine 8 (finished) created at:
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:15 +0x100
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
==================
--- FAIL: TestLock_Lock (1.00s)
    testing.go:1152: race detected during execution of test
==================
WARNING: DATA RACE
Read at 0x00c000070060 by goroutine 10:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/map_faststr.go:12 +0x45c
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:49 +0xb0
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:35 +0x9c
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:34 +0x1c8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198

Previous write at 0x00c000070060 by goroutine 11:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:107 +0x48c
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:51 +0x1a4
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:35 +0x9c
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries.func1()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:30 +0xdc

Goroutine 10 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:47 +0x288

Goroutine 11 (finished) created at:
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:29 +0x100
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
==================
==================
WARNING: DATA RACE
Read at 0x00c000117f68 by goroutine 10:
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:49 +0xc8
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:35 +0x9c
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:34 +0x1c8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198

Previous write at 0x00c000117f68 by goroutine 11:
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).Lock()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:51 +0x1b8
  github.com/RichardKnop/machinery/v2/locks/eager.(*Lock).LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager.go:35 +0x9c
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries.func1()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:30 +0xdc

Goroutine 10 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:47 +0x288

Goroutine 11 (finished) created at:
  github.com/RichardKnop/machinery/v2/locks/eager.TestLock_LockWithRetries()
      /Users/bastengao/dev/go-projects/machinery/v2/locks/eager/eager_test.go:29 +0x100
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x198
==================
--- FAIL: TestLock_LockWithRetries (21.01s)
    testing.go:1152: race detected during execution of test
FAIL
FAIL	github.com/RichardKnop/machinery/v2/locks/eager	22.130s
FAIL
```

# Solution

Replace sync.Map with map and use writing lock to wrap reading and writing operation for map.