### PR TITLE
Add sqs and dynamodb prefixes to connection urls

### DIFF
--- a/v1/factories.go
+++ b/v1/factories.go
@@ -94,6 +94,12 @@ func BrokerFactory(cnf *config.Config) (brokeriface.Broker, error) {
 		if strings.HasPrefix(cnf.Broker, "https://sqs") {
 			return sqsbroker.New(cnf), nil
 		}
+
+		const sqsPrefix = "sqs+"
+		if strings.HasPrefix(cnf.Broker, sqsPrefix) {
+			cnf.Broker = strings.TrimPrefix(cnf.Broker, sqsPrefix)
+			return sqsbroker.New(cnf), nil
+		}
 	}
 
 	if strings.HasPrefix(cnf.Broker, "gcppubsub://") {
@@ -176,6 +182,12 @@ func BackendFactory(cnf *config.Config) (backendiface.Backend, error) {
 	}
 
 	if strings.HasPrefix(cnf.ResultBackend, "https://dynamodb") {
+		return dynamobackend.New(cnf), nil
+	}
+
+	const dynamodbPrefix = "dynamodb+"
+	if strings.HasPrefix(cnf.ResultBackend, dynamodbPrefix) {
+		cnf.ResultBackend = strings.TrimPrefix(cnf.ResultBackend, dynamodbPrefix)
 		return dynamobackend.New(cnf), nil
 	}
 


### PR DESCRIPTION
After playing around with machinery on my local machine, I saw that the way that you can connect to non https aws services is with DISABLE_STRICT_SQS_CHECK. I think it is safer and more explicit to just add a prefix to the http/https urls.

Example sqs url: sqs+http://localhost:4566/000000000000
Example dynamodb url: dynamodb+http://localhost:6379/1