### PR TITLE
Set concurrency to nproc*2 in SQS broker if < 1

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -59,6 +60,9 @@ func New(cnf *config.Config) iface.Broker {
 
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcessor iface.TaskProcessor) (bool, error) {
+	if concurrency < 1 {
+		concurrency = runtime.NumCPU() * 2
+	}
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)
 	qURL := b.getQueueURL(taskProcessor)
 	//save it so that it can be used later when attempting to delete task


### PR DESCRIPTION
According to doc, concurrency = 0 means unlimited. The SQS broker didn't handle this situation. This PR sets concurrency to nproc*2 when the input is < 1.