### PR TITLE
Use GOMAXPROCS instead of NumCPU

### DIFF
--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -77,7 +77,7 @@ func (b *BrokerGR) StartConsuming(consumerTag string, concurrency int, taskProce
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = runtime.NumCPU() * 2
+		concurrency = runtime.GOMAXPROCS(0) * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -65,7 +65,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = runtime.NumCPU() * 2
+		concurrency = runtime.GOMAXPROCS(0) * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)

--- a/v2/brokers/redis/goredis.go
+++ b/v2/brokers/redis/goredis.go
@@ -72,7 +72,7 @@ func (b *BrokerGR) StartConsuming(consumerTag string, concurrency int, taskProce
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = runtime.NumCPU() * 2
+		concurrency = runtime.GOMAXPROCS(0) * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)

--- a/v2/brokers/redis/redis.go
+++ b/v2/brokers/redis/redis.go
@@ -65,7 +65,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency int, taskProcess
 	defer b.consumingWG.Done()
 
 	if concurrency < 1 {
-		concurrency = runtime.NumCPU() * 2
+		concurrency = runtime.GOMAXPROCS(0) * 2
 	}
 
 	b.Broker.StartConsuming(consumerTag, concurrency, taskProcessor)


### PR DESCRIPTION
We can customize the number of CPU the application can use by setting gomaxprocs
therefore instead of using the max amount of cpu use the custom allowed max cpu count