### PR TITLE
fix: overflow when parsing a huge uint64 number

### DIFF
--- a/v1/tasks/reflect_test.go
+++ b/v1/tasks/reflect_test.go
@@ -82,6 +82,12 @@ var (
 			expectedValue: uint64(185135722552891243),
 		},
 		{
+			name:          "uint64",
+			value:         json.Number("9223372036854775808"), // math.MaxInt64 + 1
+			expectedType:  "uint64",
+			expectedValue: uint64(9223372036854775808),
+		},
+		{
 			name:          "float32",
 			value:         json.Number("0.5"),
 			expectedType:  "float32",

--- a/v2/tasks/reflect_test.go
+++ b/v2/tasks/reflect_test.go
@@ -82,6 +82,12 @@ var (
 			expectedValue: uint64(185135722552891243),
 		},
 		{
+			name:          "uint64",
+			value:         json.Number("9223372036854775808"), // math.MaxInt64 + 1
+			expectedType:  "uint64",
+			expectedValue: uint64(9223372036854775808),
+		},
+		{
 			name:          "float32",
 			value:         json.Number("0.5"),
 			expectedType:  "float32",


### PR DESCRIPTION
Such as 1<<64 - 1, math.MaxInt64 + 1, etc.
Sending these values to task arguments will cause a panic. These values are legal golang uint64 values.