### PR TITLE
fix(windows): fixing tests on windows

### DIFF
--- a/v1/config/file.go
+++ b/v1/config/file.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	ConfigMaxSize = 1000
+)
+
 // NewFromYaml creates a config object from YAML file
 func NewFromYaml(cnfPath string, keepReloading bool) (*Config, error) {
 	cnf, err := fromFile(cnfPath)
@@ -50,7 +54,7 @@ func ReadFromFile(cnfPath string) ([]byte, error) {
 	}
 
 	// Config file found, let's try to read it
-	data := make([]byte, 1000)
+	data := make([]byte, ConfigMaxSize)
 	count, err := file.Read(data)
 	if err != nil {
 		return nil, fmt.Errorf("Read from file error: %s", err)

--- a/v1/utils/utils.go
+++ b/v1/utils/utils.go
@@ -3,12 +3,20 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 const (
 	LockKeyPrefix = "machinery_lock_"
+	windows       = "windows"
 )
 
 func GetLockName(name, spec string) string {
-	return LockKeyPrefix + filepath.Base(os.Args[0]) + name + spec
+	cmd := filepath.Base(os.Args[0])
+	if runtime.GOOS == windows {
+		cmd = strings.ReplaceAll(cmd, ".exe", "")
+	}
+
+	return strings.Join([]string{LockKeyPrefix, cmd, name, spec}, "")
 }


### PR DESCRIPTION
Found a few windows specific unit test issues

- `config.TestReadFromFile` breaks because windows reads in carriage returns and the hardcoded string does not have these. Fixed by making test content on the fly.
- `util.GetLockName` failes because the expected output does not contain a file with `.exe` extension. Fixed by removing `.exe` on Windows