### PR TITLE
switching task.Headers to use http.Header

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -230,7 +231,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 		false,                       // mandatory
 		false,                       // immediate
 		amqp.Publishing{
-			Headers:      amqp.Table(signature.Headers),
+			Headers:      convertHeaders(signature.Headers),
 			ContentType:  "application/json",
 			Body:         msg,
 			Priority:     signature.Priority,
@@ -398,7 +399,7 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 		false,                       // mandatory
 		false,                       // immediate
 		amqp.Publishing{
-			Headers:      amqp.Table(signature.Headers),
+			Headers:      convertHeaders(signature.Headers),
 			ContentType:  "application/json",
 			Body:         message,
 			DeliveryMode: amqp.Persistent,
@@ -489,4 +490,14 @@ func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	}
 
 	return dumper.Signatures, nil
+}
+
+func convertHeaders(headers http.Header) amqp.Table {
+	table := make(amqp.Table, len(headers))
+
+	for k, v := range headers {
+		table[k] = v
+	}
+
+	return table
 }

--- a/v1/brokers/amqp/amqp_concurrence_test.go
+++ b/v1/brokers/amqp/amqp_concurrence_test.go
@@ -2,12 +2,13 @@ package amqp
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/streadway/amqp"
-	"testing"
-	"time"
 )
 
 type doNothingProcessor struct{}

--- a/v1/server_test.go
+++ b/v1/server_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	
+
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 )
@@ -37,7 +37,7 @@ func TestRegisterTaskInRaceCondition(t *testing.T) {
 	t.Parallel()
 
 	server := getTestServer(t)
-	for i:=0; i<10; i++ {
+	for i := 0; i < 10; i++ {
 		go func() {
 			err := server.RegisterTask("test_task", func() error { return nil })
 			assert.NoError(t, err)

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -2,8 +2,10 @@ package tasks
 
 import (
 	"fmt"
-	"github.com/RichardKnop/machinery/v1/utils"
+	"net/http"
 	"time"
+
+	"github.com/RichardKnop/machinery/v1/utils"
 
 	"github.com/google/uuid"
 )
@@ -15,33 +17,6 @@ type Arg struct {
 	Value interface{} `bson:"value"`
 }
 
-// Headers represents the headers which should be used to direct the task
-type Headers map[string]interface{}
-
-// Set on Headers implements opentracing.TextMapWriter for trace propagation
-func (h Headers) Set(key, val string) {
-	h[key] = val
-}
-
-// ForeachKey on Headers implements opentracing.TextMapReader for trace propagation.
-// It is essentially the same as the opentracing.TextMapReader implementation except
-// for the added casting from interface{} to string.
-func (h Headers) ForeachKey(handler func(key, val string) error) error {
-	for k, v := range h {
-		// Skip any non string values
-		stringValue, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		if err := handler(k, stringValue); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Signature represents a single task invocation
 type Signature struct {
 	UUID           string
@@ -51,7 +26,7 @@ type Signature struct {
 	GroupUUID      string
 	GroupTaskCount int
 	Args           []Arg
-	Headers        Headers
+	Headers        http.Header
 	Priority       uint8
 	Immutable      bool
 	RetryCount     int

--- a/v1/tracing/tracing.go
+++ b/v1/tracing/tracing.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 
@@ -20,9 +21,9 @@ var (
 
 // StartSpanFromHeaders will extract a span from the signature headers
 // and start a new span with the given operation name.
-func StartSpanFromHeaders(headers tasks.Headers, operationName string) opentracing.Span {
+func StartSpanFromHeaders(headers http.Header, operationName string) opentracing.Span {
 	// Try to extract the span context from the carrier.
-	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, headers)
+	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, headers)
 
 	// Create a new span from the span context if found or start a new trace with the function name.
 	// For clarity add the machinery component tag.
@@ -41,13 +42,13 @@ func StartSpanFromHeaders(headers tasks.Headers, operationName string) opentraci
 }
 
 // HeadersWithSpan will inject a span into the signature headers
-func HeadersWithSpan(headers tasks.Headers, span opentracing.Span) tasks.Headers {
+func HeadersWithSpan(headers http.Header, span opentracing.Span) http.Header {
 	// check if the headers aren't nil
 	if headers == nil {
-		headers = make(tasks.Headers)
+		headers = make(http.Header)
 	}
 
-	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.TextMap, headers); err != nil {
+	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, headers); err != nil {
 		span.LogFields(opentracing_log.Error(err))
 	}
 

--- a/v1/tracing/tracing.go
+++ b/v1/tracing/tracing.go
@@ -23,7 +23,7 @@ var (
 // and start a new span with the given operation name.
 func StartSpanFromHeaders(headers http.Header, operationName string) opentracing.Span {
 	// Try to extract the span context from the carrier.
-	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, headers)
+	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(headers))
 
 	// Create a new span from the span context if found or start a new trace with the function name.
 	// For clarity add the machinery component tag.
@@ -48,7 +48,7 @@ func HeadersWithSpan(headers http.Header, span opentracing.Span) http.Header {
 		headers = make(http.Header)
 	}
 
-	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, headers); err != nil {
+	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(headers)); err != nil {
 		span.LogFields(opentracing_log.Error(err))
 	}
 

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	
+
 	"github.com/RichardKnop/machinery/v1/backends/amqp"
 	"github.com/RichardKnop/machinery/v1/brokers/errs"
 	"github.com/RichardKnop/machinery/v1/log"

--- a/v1/worker_test.go
+++ b/v1/worker_test.go
@@ -18,7 +18,7 @@ func TestRedactURL(t *testing.T) {
 
 func TestPreConsumeHandler(t *testing.T) {
 	t.Parallel()
-	
+
 	worker := &machinery.Worker{}
 
 	worker.SetPreConsumeHandler(SamplePreConsumeHandler)

--- a/v2/brokers/amqp/amqp.go
+++ b/v2/brokers/amqp/amqp.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -230,7 +231,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 		false,                       // mandatory
 		false,                       // immediate
 		amqp.Publishing{
-			Headers:      amqp.Table(signature.Headers),
+			Headers:      convertHeaders(signature.Headers),
 			ContentType:  "application/json",
 			Body:         msg,
 			Priority:     signature.Priority,
@@ -398,7 +399,7 @@ func (b *Broker) delay(signature *tasks.Signature, delayMs int64) error {
 		false,                       // mandatory
 		false,                       // immediate
 		amqp.Publishing{
-			Headers:      amqp.Table(signature.Headers),
+			Headers:      convertHeaders(signature.Headers),
 			ContentType:  "application/json",
 			Body:         message,
 			DeliveryMode: amqp.Persistent,
@@ -489,4 +490,14 @@ func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	}
 
 	return dumper.Signatures, nil
+}
+
+func convertHeaders(headers http.Header) amqp.Table {
+	table := make(amqp.Table, len(headers))
+
+	for k, v := range headers {
+		table[k] = v
+	}
+
+	return table
 }

--- a/v2/tasks/signature.go
+++ b/v2/tasks/signature.go
@@ -2,8 +2,10 @@ package tasks
 
 import (
 	"fmt"
-	"github.com/RichardKnop/machinery/v2/utils"
+	"net/http"
 	"time"
+
+	"github.com/RichardKnop/machinery/v2/utils"
 
 	"github.com/google/uuid"
 )
@@ -15,33 +17,6 @@ type Arg struct {
 	Value interface{} `bson:"value"`
 }
 
-// Headers represents the headers which should be used to direct the task
-type Headers map[string]interface{}
-
-// Set on Headers implements opentracing.TextMapWriter for trace propagation
-func (h Headers) Set(key, val string) {
-	h[key] = val
-}
-
-// ForeachKey on Headers implements opentracing.TextMapReader for trace propagation.
-// It is essentially the same as the opentracing.TextMapReader implementation except
-// for the added casting from interface{} to string.
-func (h Headers) ForeachKey(handler func(key, val string) error) error {
-	for k, v := range h {
-		// Skip any non string values
-		stringValue, ok := v.(string)
-		if !ok {
-			continue
-		}
-
-		if err := handler(k, stringValue); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Signature represents a single task invocation
 type Signature struct {
 	UUID           string
@@ -51,7 +26,7 @@ type Signature struct {
 	GroupUUID      string
 	GroupTaskCount int
 	Args           []Arg
-	Headers        Headers
+	Headers        http.Header
 	Priority       uint8
 	Immutable      bool
 	RetryCount     int

--- a/v2/tracing/tracing.go
+++ b/v2/tracing/tracing.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/RichardKnop/machinery/v2/tasks"
 
@@ -20,9 +21,9 @@ var (
 
 // StartSpanFromHeaders will extract a span from the signature headers
 // and start a new span with the given operation name.
-func StartSpanFromHeaders(headers tasks.Headers, operationName string) opentracing.Span {
+func StartSpanFromHeaders(headers http.Header, operationName string) opentracing.Span {
 	// Try to extract the span context from the carrier.
-	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, headers)
+	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, headers)
 
 	// Create a new span from the span context if found or start a new trace with the function name.
 	// For clarity add the machinery component tag.
@@ -41,13 +42,13 @@ func StartSpanFromHeaders(headers tasks.Headers, operationName string) opentraci
 }
 
 // HeadersWithSpan will inject a span into the signature headers
-func HeadersWithSpan(headers tasks.Headers, span opentracing.Span) tasks.Headers {
+func HeadersWithSpan(headers http.Header, span opentracing.Span) tasks.Headers {
 	// check if the headers aren't nil
 	if headers == nil {
-		headers = make(tasks.Headers)
+		headers = make(http.Header)
 	}
 
-	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.TextMap, headers); err != nil {
+	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, headers); err != nil {
 		span.LogFields(opentracing_log.Error(err))
 	}
 

--- a/v2/tracing/tracing.go
+++ b/v2/tracing/tracing.go
@@ -42,7 +42,7 @@ func StartSpanFromHeaders(headers http.Header, operationName string) opentracing
 }
 
 // HeadersWithSpan will inject a span into the signature headers
-func HeadersWithSpan(headers http.Header, span opentracing.Span) tasks.Headers {
+func HeadersWithSpan(headers http.Header, span opentracing.Span) http.Header {
 	// check if the headers aren't nil
 	if headers == nil {
 		headers = make(http.Header)

--- a/v2/tracing/tracing.go
+++ b/v2/tracing/tracing.go
@@ -23,7 +23,7 @@ var (
 // and start a new span with the given operation name.
 func StartSpanFromHeaders(headers http.Header, operationName string) opentracing.Span {
 	// Try to extract the span context from the carrier.
-	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, headers)
+	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(headers))
 
 	// Create a new span from the span context if found or start a new trace with the function name.
 	// For clarity add the machinery component tag.
@@ -48,7 +48,7 @@ func HeadersWithSpan(headers http.Header, span opentracing.Span) tasks.Headers {
 		headers = make(http.Header)
 	}
 
-	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, headers); err != nil {
+	if err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(headers)); err != nil {
 		span.LogFields(opentracing_log.Error(err))
 	}
 


### PR DESCRIPTION
To make opentracing compatible with opentelemetry, we should be using http Headers.

Here's the relevant code in the opentracing shim for opentelemetry:
https://github.com/open-telemetry/opentelemetry-go/blob/main/bridge/opentracing/bridge.go#L646

Making this change keeps `machinery` compatible with `opentracing` and enables integration with `opentelemetry`.