### PR TITLE
AMQP: nack the message with requeue false when IgnoreWhenTaskNotRegistered

### DIFF
--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -321,13 +321,11 @@ func (b *Broker) consumeOne(delivery amqp.Delivery, taskProcessor iface.TaskProc
 	// If the task is not registered, we nack it and requeue,
 	// there might be different workers for processing specific tasks
 	if !b.IsTaskRegistered(signature.Name) {
-		requeue = true
-		log.INFO.Printf("Task not registered with this worker. Requeing message: %s", delivery.Body)
-
 		if !signature.IgnoreWhenTaskNotRegistered {
-			delivery.Nack(multiple, requeue)
+			requeue = true
 		}
-
+		log.INFO.Printf("Task not registered with this worker. Requeuing: %t with message: %s", requeue, delivery.Body)
+		delivery.Nack(multiple, requeue)
 		return nil
 	}
 

--- a/v2/brokers/amqp/amqp.go
+++ b/v2/brokers/amqp/amqp.go
@@ -321,13 +321,11 @@ func (b *Broker) consumeOne(delivery amqp.Delivery, taskProcessor iface.TaskProc
 	// If the task is not registered, we nack it and requeue,
 	// there might be different workers for processing specific tasks
 	if !b.IsTaskRegistered(signature.Name) {
-		requeue = true
-		log.INFO.Printf("Task not registered with this worker. Requeing message: %s", delivery.Body)
-
 		if !signature.IgnoreWhenTaskNotRegistered {
-			delivery.Nack(multiple, requeue)
+			requeue = true
 		}
-
+		log.INFO.Printf("Task not registered with this worker. Requeuing: %t with message: %s", requeue, delivery.Body)
+		delivery.Nack(multiple, requeue)
 		return nil
 	}
 


### PR DESCRIPTION
## Description

This pull request addresses an issue related to the handling of AMQP based task messages when a task is not registered with the worker, and `IgnoreWhenTaskNotRegistered` is set. The existing logic is adjusted to correctly NACK the message with `requeue=false` in these scenarios.

## Changes Made

- Adjust the logic to properly NACK the AMQP message with `requeue=false` when `IgnoreWhenTaskNotRegistered` is true.

## Impact

This fix ensures consistent and correct behavior in handling AMQP messages, especially in scenarios where tasks are not registered, and `IgnoreWhenTaskNotRegistered` is configured.
