### PR TITLE
Support Redis cluster with single endpoint configuration

### DIFF
--- a/v2/backends/redis/goredis.go
+++ b/v2/backends/redis/goredis.go
@@ -53,7 +53,11 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 
-	b.rclient = redis.NewUniversalClient(ropt)
+	if cnf.Redis != nil && cnf.Redis.ClusterEnabled {
+		b.rclient = redis.NewClusterClient(ropt.Cluster())
+	} else {
+		b.rclient = redis.NewUniversalClient(ropt)
+	}
 	b.redsync = redsync.New(redsyncgoredis.NewPool(b.rclient))
 	return b
 }

--- a/v2/brokers/redis/goredis.go
+++ b/v2/brokers/redis/goredis.go
@@ -57,8 +57,12 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 
-	b.rclient = redis.NewUniversalClient(ropt)
-	if cnf.Redis.DelayedTasksKey != "" {
+	if cnf.Redis != nil && cnf.Redis.ClusterEnabled {
+		b.rclient = redis.NewClusterClient(ropt.Cluster())
+	} else {
+		b.rclient = redis.NewUniversalClient(ropt)
+	}
+	if cnf.Redis != nil && cnf.Redis.DelayedTasksKey != "" {
 		b.redisDelayedTasksKey = cnf.Redis.DelayedTasksKey
 	} else {
 		b.redisDelayedTasksKey = defaultRedisDelayedTasksKey

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -150,6 +150,10 @@ type RedisConfig struct {
 
 	// MasterName specifies a redis master name in order to configure a sentinel-backed redis FailoverClient
 	MasterName string `yaml:"master_name" envconfig:"REDIS_MASTER_NAME"`
+
+	// ClusterEnabled specifies whether cluster mode is enabled, regardless the number of addresses.
+	// This helps create ClusterClient for Redis servers that enabled cluster mode with 1 node, or using AWS configuration endpoint
+	ClusterEnabled bool `yaml:"cluster_enabled" envconfig:"REDIS_CLUSTER_ENABLED"`
 }
 
 // GCPPubSubConfig wraps GCP PubSub related configuration

--- a/v2/locks/redis/redis.go
+++ b/v2/locks/redis/redis.go
@@ -1,13 +1,15 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/RichardKnop/machinery/v2/config"
 	"github.com/redis/go-redis/v9"
+
+	"github.com/RichardKnop/machinery/v2/config"
 )
 
 var (
@@ -43,7 +45,11 @@ func New(cnf *config.Config, addrs []string, db, retries int) Lock {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 
-	lock.rclient = redis.NewUniversalClient(ropt)
+	if cnf.Redis != nil && cnf.Redis.ClusterEnabled {
+		lock.rclient = redis.NewClusterClient(ropt.Cluster())
+	} else {
+		lock.rclient = redis.NewUniversalClient(ropt)
+	}
 
 	return lock
 }
@@ -52,7 +58,7 @@ func (r Lock) LockWithRetries(key string, unixTsToExpireNs int64) error {
 	for i := 0; i <= r.retries; i++ {
 		err := r.Lock(key, unixTsToExpireNs)
 		if err == nil {
-			//成功拿到锁，返回
+			// 成功拿到锁，返回
 			return nil
 		}
 
@@ -64,7 +70,7 @@ func (r Lock) LockWithRetries(key string, unixTsToExpireNs int64) error {
 func (r Lock) Lock(key string, unixTsToExpireNs int64) error {
 	now := time.Now().UnixNano()
 	expiration := time.Duration(unixTsToExpireNs + 1 - now)
-	ctx := r.rclient.Context()
+	ctx := context.Background()
 
 	success, err := r.rclient.SetNX(ctx, key, unixTsToExpireNs, expiration).Result()
 	if err != nil {


### PR DESCRIPTION
With Redis cluster configurations that have only one endpoint (AWS ElastiCache for example), the go-redis `UniversalClient` will create `Client` object, not `ClusterClient`, which will not be able to execute commands on cluster nodes.

This pull request added `ClusterEnabled` config in `RedisConfig` struct to enable configuring support for Redis cluster specifically.