### PR TITLE
Fixup Redis lock context compilation error

### DIFF
--- a/v2/locks/redis/redis.go
+++ b/v2/locks/redis/redis.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -64,7 +65,8 @@ func (r Lock) LockWithRetries(key string, unixTsToExpireNs int64) error {
 func (r Lock) Lock(key string, unixTsToExpireNs int64) error {
 	now := time.Now().UnixNano()
 	expiration := time.Duration(unixTsToExpireNs + 1 - now)
-	ctx := r.rclient.Context()
+	// ctx := r.rclient.Context()
+	ctx := context.Background()
 
 	success, err := r.rclient.SetNX(ctx, key, unixTsToExpireNs, expiration).Result()
 	if err != nil {


### PR DESCRIPTION
The go-redis v9 removed the `.Context()` method on its client; the `v1` package was updated accordingly in #793, but the `v2` package was left out which this PR fixes. Also, see #803 to follow-up on what context should be used.