### PR TITLE
fix v2 go-redis tls bug

### DIFF
--- a/v2/backends/redis/goredis.go
+++ b/v2/backends/redis/goredis.go
@@ -52,6 +52,9 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
+	if cnf.TLSConfig != nil {
+		ropt.TLSConfig = cnf.TLSConfig
+	}
 
 	if cnf.Redis != nil && cnf.Redis.SentinelPassword != "" {
 		ropt.SentinelPassword = cnf.Redis.SentinelPassword

--- a/v2/brokers/redis/goredis.go
+++ b/v2/brokers/redis/goredis.go
@@ -56,6 +56,9 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName
 	}
+	if cnf.TLSConfig != nil {
+		ropt.TLSConfig = cnf.TLSConfig
+	}
 
 	if cnf.Redis != nil && cnf.Redis.SentinelPassword != "" {
 		ropt.SentinelPassword = cnf.Redis.SentinelPassword


### PR DESCRIPTION
This fixes a bug where the TLSConfig options would not be passed on to the v2 go-redis broker and backend.