### PR TITLE
fix-v1-redis-sentinel-custom-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ For example:
 
 1. `redis://localhost:6379`, or with password `redis://password@localhost:6379`
 2. `redis+socket://password@/path/to/file.sock:/0`
-3. cluster/sentinel `redis://host1:port1,host2:port2,host3:port3`
-4. cluster/sentinel with password `redis://pass@host1:port1,host2:port2,host3:port3`
+3. cluster/sentinel `redis://host1:port1,host2:port2,host3:port3/0`
+4. cluster/sentinel with password `redis://pass@host1:port1,host2:port2,host3:port3/0`
 
 ##### Memcache
 


### PR DESCRIPTION
Problem
- Previously, in Sentinel mode the system ignored a custom Redis DB index specified in the address (e.g. the `/8` suffix), defaulting to DB 0 and potentially writing data to the wrong database.

Solution
- Parse an optional `/db` suffix from the last broker address in the sentinel address list (e.g. `127.0.0.1:26381/8`) and use the parsed value as the Redis DB index;
- Remove the `/db` suffix from the last address so the resulting broker list passed to the client remains in `host:port` format;
- If no `/db` is provided, default to db=0 for backward compatibility.

Impact
- Fixes incorrect DB selection in Sentinel mode, improving data isolation correctness;
- Backwards compatible for configurations without `/db`.
